### PR TITLE
Add dynamic lighting and particle rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0.1"
+bumpalo = "3.4"
 byteorder = "1.2.1"
 cgmath = "0.17.0"
 chrono = "0.4.0"
@@ -32,7 +33,7 @@ structopt = "0.3.12"
 strum = "0.18.0"
 strum_macros = "0.18.0"
 # wgpu = "0.6.0"
-wgpu = { git = "https://github.com/gfx-rs/wgpu-rs", rev = "d272a69" }
+wgpu = { git = "https://github.com/gfx-rs/wgpu-rs", rev = "08497ce", features = ["trace"] }
 
 # "winit" = "0.22.2"
 # necessary until winit/#1524 is merged

--- a/shaders/alias.frag
+++ b/shaders/alias.frag
@@ -11,12 +11,16 @@ layout(set = 2, binding = 0) uniform texture2D u_diffuse_texture;
 
 layout(location = 0) out vec4 diffuse_attachment;
 layout(location = 1) out vec4 normal_attachment;
+layout(location = 2) out vec4 light_attachment;
 
 void main() {
   diffuse_attachment = texture(
     sampler2D(u_diffuse_texture, u_diffuse_sampler),
     f_diffuse
   );
+
+  // TODO: get ambient light from uniform
+  light_attachment = vec4(1.0, 1.0, 1.0, 1.0);
 
   // rescale normal to [0, 1]
   normal_attachment = vec4(f_normal / 2.0 + 0.5, 1.0);

--- a/shaders/brush.vert
+++ b/shaders/brush.vert
@@ -10,6 +10,11 @@ layout(location = 2) in vec2 a_diffuse;
 layout(location = 3) in vec2 a_lightmap;
 layout(location = 4) in uvec4 a_lightmap_anim;
 
+layout(push_constant) uniform PushConstants {
+  mat4 transform;
+  mat4 model;
+} push_constants;
+
 layout(location = 0) out vec3 f_normal;
 layout(location = 1) out vec2 f_diffuse;
 layout(location = 2) out vec2 f_lightmap;
@@ -20,11 +25,6 @@ layout(set = 0, binding = 0) uniform FrameUniforms {
     vec4 camera_pos;
     float time;
 } frame_uniforms;
-
-layout(set = 1, binding = 0) uniform EntityUniforms {
-    mat4 u_transform;
-    mat4 u_model;
-} entity_uniforms;
 
 layout(set = 2, binding = 2) uniform TextureUniforms {
     uint kind;
@@ -48,9 +48,9 @@ void main() {
         f_diffuse = a_diffuse;
     }
 
-    f_normal = mat3(transpose(inverse(entity_uniforms.u_model))) * convert(a_normal);
+    f_normal = mat3(transpose(inverse(push_constants.model))) * convert(a_normal);
     f_lightmap = a_lightmap;
     f_lightmap_anim = a_lightmap_anim;
-    gl_Position = entity_uniforms.u_transform * vec4(convert(a_position), 1.0);
+    gl_Position = push_constants.transform * vec4(convert(a_position), 1.0);
 
 }

--- a/shaders/deferred.frag
+++ b/shaders/deferred.frag
@@ -1,16 +1,32 @@
 #version 450
 
+// if this is changed, it must also be changed in client::entity
+const uint MAX_LIGHTS = 32;
+
 layout(location = 0) in vec2 a_texcoord;
 
 layout(set = 0, binding = 0) uniform sampler u_sampler;
 layout(set = 0, binding = 1) uniform texture2DMS u_diffuse;
 layout(set = 0, binding = 2) uniform texture2DMS u_normal;
-layout(set = 0, binding = 3) uniform texture2DMS u_depth;
-layout(set = 0, binding = 4) uniform DeferredUniforms {
+layout(set = 0, binding = 3) uniform texture2DMS u_light;
+layout(set = 0, binding = 4) uniform texture2DMS u_depth;
+layout(set = 0, binding = 5) uniform DeferredUniforms {
   mat4 inv_projection;
+  uint light_count;
+  uint _pad1;
+  uvec2 _pad2;
+  vec4 lights[MAX_LIGHTS];
 } u_deferred;
 
 layout(location = 0) out vec4 color_attachment;
+
+vec3 dlight_origin(vec4 dlight) {
+  return dlight.xyz;
+}
+
+float dlight_radius(vec4 dlight) {
+  return dlight.w;
+}
 
 vec3 reconstruct_position(float depth) {
   float x = a_texcoord.s * 2.0 - 1.0;
@@ -25,7 +41,24 @@ void main() {
   ivec2 texcoord = ivec2(vec2(dims) * a_texcoord);
   vec4 in_color = texelFetch(sampler2DMS(u_diffuse, u_sampler), texcoord, gl_SampleID);
   vec3 in_normal = texelFetch(sampler2DMS(u_normal, u_sampler), texcoord, gl_SampleID).xyz;
+  float in_light = texelFetch(sampler2DMS(u_light, u_sampler), texcoord, gl_SampleID).x;
   float in_depth = texelFetch(sampler2DMS(u_depth, u_sampler), texcoord, gl_SampleID).x;
   vec3 position = reconstruct_position(in_depth);
-  color_attachment = in_color;
+
+  vec4 out_color = in_color;
+  float light = in_light;
+  for (uint i = 0; i < u_deferred.light_count && i < MAX_LIGHTS; i++) {
+    vec4 dlight = u_deferred.lights[i];
+    float dist = abs(distance(dlight_origin(dlight), position));
+    float radius = dlight_radius(dlight);
+
+    if (dist < radius) {
+      // linear attenuation
+      light += (radius - dist) / radius;
+    }
+  }
+
+  light = min(light, 1.0);
+
+  color_attachment = vec4(out_color.rgb * light, 1.0);
 }

--- a/shaders/deferred.frag
+++ b/shaders/deferred.frag
@@ -27,5 +27,5 @@ void main() {
   vec3 in_normal = texelFetch(sampler2DMS(u_normal, u_sampler), texcoord, gl_SampleID).xyz;
   float in_depth = texelFetch(sampler2DMS(u_depth, u_sampler), texcoord, gl_SampleID).x;
   vec3 position = reconstruct_position(in_depth);
-  color_attachment = vec4(position, 1.0);
+  color_attachment = in_color;
 }

--- a/shaders/particle.frag
+++ b/shaders/particle.frag
@@ -3,7 +3,7 @@
 layout(location = 0) in vec2 f_texcoord;
 
 layout(push_constant) uniform PushConstants {
-  uint color;
+  layout(offset = 64) uint color;
 } push_constants;
 
 layout(set = 0, binding = 0) uniform sampler u_sampler;
@@ -15,8 +15,7 @@ layout(location = 2) out vec4 light_attachment;
 
 void main() {
   vec4 tex_color = texture(
-                           sampler2D(u_texture[push_constants.color], u_sampler),
-    //sampler2D(u_texture[push_constants.color], u_sampler),
+    sampler2D(u_texture[push_constants.color], u_sampler),
     f_texcoord
   );
 

--- a/shaders/particle.frag
+++ b/shaders/particle.frag
@@ -1,0 +1,29 @@
+#version 450
+
+layout(location = 0) in vec2 f_texcoord;
+
+layout(push_constant) uniform PushConstants {
+  uint color;
+} push_constants;
+
+layout(set = 0, binding = 0) uniform sampler u_sampler;
+layout(set = 0, binding = 1) uniform texture2D u_texture[256];
+
+layout(location = 0) out vec4 diffuse_attachment;
+// layout(location = 1) out vec4 normal_attachment;
+layout(location = 2) out vec4 light_attachment;
+
+void main() {
+  vec4 tex_color = texture(
+                           sampler2D(u_texture[push_constants.color], u_sampler),
+    //sampler2D(u_texture[push_constants.color], u_sampler),
+    f_texcoord
+  );
+
+  if (tex_color.a == 0.0) {
+    discard;
+  }
+
+  diffuse_attachment = tex_color;
+  light_attachment = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/shaders/particle.vert
+++ b/shaders/particle.vert
@@ -1,0 +1,15 @@
+#version 450
+
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec2 a_texcoord;
+
+layout(push_constant) uniform PushConstants {
+  mat4 transform;
+} push_constants;
+
+layout(location = 0) out vec2 f_texcoord;
+
+void main() {
+  f_texcoord = a_texcoord;
+  gl_Position = push_constants.transform * vec4(a_position, 1.0);
+}

--- a/shaders/sprite.frag
+++ b/shaders/sprite.frag
@@ -11,10 +11,12 @@ layout(set = 2, binding = 0) uniform texture2D u_diffuse_texture;
 
 layout(location = 0) out vec4 diffuse_attachment;
 layout(location = 1) out vec4 normal_attachment;
+layout(location = 2) out vec4 light_attachment;
 
 void main() {
   diffuse_attachment = texture(sampler2D(u_diffuse_texture, u_diffuse_sampler), f_diffuse);
 
   // rescale normal to [0, 1]
   normal_attachment = vec4(f_normal / 2.0 + 0.5, 1.0);
+  light_attachment = vec4(1.0, 1.0, 1.0, 1.0);
 }

--- a/src/client/cvars.rs
+++ b/src/client/cvars.rs
@@ -54,5 +54,10 @@ pub fn register_cvars(cvars: &CvarRegistry) -> Result<(), ConsoleError> {
     cvars.register("v_kickroll", "0.6")?;
     cvars.register("v_kicktime", "0.5")?;
 
+    // some server cvars are needed by the client, but if the server is running
+    // in the same process they will have been set already, so we can ignore
+    // the duplicate cvar error
+    let _ = cvars.register("sv_gravity", "800");
+
     Ok(())
 }

--- a/src/client/entity/mod.rs
+++ b/src/client/entity/mod.rs
@@ -21,14 +21,15 @@
 pub mod particle;
 
 use crate::common::{
-    engine,
     alloc::LinkedSlab,
+    engine,
     net::{EntityEffects, EntityState},
 };
 
 use cgmath::{Deg, Vector3};
 use chrono::Duration;
 
+// if this is changed, it must also be changed in deferred.frag
 pub const MAX_LIGHTS: usize = 32;
 pub const MAX_BEAMS: usize = 24;
 pub const MAX_TEMP_ENTITIES: usize = 64;
@@ -117,6 +118,7 @@ impl ClientEntity {
 }
 
 /// A descriptor used to spawn dynamic lights.
+#[derive(Clone, Debug)]
 pub struct LightDesc {
     /// The origin of the light.
     pub origin: Vector3<f32>,
@@ -135,6 +137,7 @@ pub struct LightDesc {
 }
 
 /// A dynamic point light.
+#[derive(Clone, Debug)]
 pub struct Light {
     origin: Vector3<f32>,
     init_radius: f32,
@@ -168,7 +171,7 @@ impl Light {
     pub fn radius(&self, time: Duration) -> f32 {
         let lived = time - self.spawned;
         let decay = self.decay_rate * engine::duration_to_f32(lived);
-        let radius = (self.init_radius - decay).min(0.0);
+        let radius = (self.init_radius - decay).max(0.0);
 
         if let Some(min) = self.min_radius {
             if radius < min {

--- a/src/client/entity/mod.rs
+++ b/src/client/entity/mod.rs
@@ -20,15 +20,98 @@
 
 pub mod particle;
 
-use cgmath::Vector3;
+use crate::common::net::{EntityState, EntityEffects};
+
+use cgmath::{Deg, Vector3};
 use chrono::Duration;
 
+pub const MAX_BEAMS: usize = 24;
+
+#[derive(Debug)]
+pub struct ClientEntity {
+    pub force_link: bool,
+    pub baseline: EntityState,
+    pub msg_time: Duration,
+    pub msg_origins: [Vector3<f32>; 2],
+    pub origin: Vector3<f32>,
+    pub msg_angles: [Vector3<Deg<f32>>; 2],
+    pub angles: Vector3<Deg<f32>>,
+    pub model_id: usize,
+    pub frame_id: usize,
+    pub skin_id: usize,
+    pub sync_base: Duration,
+    pub effects: EntityEffects,
+    // vis_frame: usize,
+}
+
+impl ClientEntity {
+    pub fn from_baseline(baseline: EntityState) -> ClientEntity {
+        ClientEntity {
+            force_link: false,
+            baseline: baseline.clone(),
+            msg_time: Duration::zero(),
+            msg_origins: [Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.0, 0.0, 0.0)],
+            origin: baseline.origin,
+            msg_angles: [
+                Vector3::new(Deg(0.0), Deg(0.0), Deg(0.0)),
+                Vector3::new(Deg(0.0), Deg(0.0), Deg(0.0)),
+            ],
+            angles: baseline.angles,
+            model_id: baseline.model_id,
+            frame_id: baseline.frame_id,
+            skin_id: baseline.skin_id,
+            sync_base: Duration::zero(),
+            effects: baseline.effects,
+        }
+    }
+
+    pub fn uninitialized() -> ClientEntity {
+        ClientEntity {
+            force_link: false,
+            baseline: EntityState::uninitialized(),
+            msg_time: Duration::zero(),
+            msg_origins: [Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.0, 0.0, 0.0)],
+            origin: Vector3::new(0.0, 0.0, 0.0),
+            msg_angles: [
+                Vector3::new(Deg(0.0), Deg(0.0), Deg(0.0)),
+                Vector3::new(Deg(0.0), Deg(0.0), Deg(0.0)),
+            ],
+            angles: Vector3::new(Deg(0.0), Deg(0.0), Deg(0.0)),
+            model_id: 0,
+            frame_id: 0,
+            skin_id: 0,
+            sync_base: Duration::zero(),
+            effects: EntityEffects::empty(),
+        }
+    }
+
+    pub fn get_origin(&self) -> Vector3<f32> {
+        self.origin
+    }
+
+    pub fn get_angles(&self) -> Vector3<Deg<f32>> {
+        self.angles
+    }
+
+    pub fn get_model_id(&self) -> usize {
+        self.model_id
+    }
+
+    pub fn get_frame_id(&self) -> usize {
+        self.frame_id
+    }
+
+    pub fn get_skin_id(&self) -> usize {
+        self.skin_id
+    }
+}
+
 pub struct Light {
-    origin: Vector3<f32>,
-    radius: f32,
-    decay_rate: f32,
-    min_light: f32,
-    expire: Duration,
+    pub origin: Vector3<f32>,
+    pub radius: f32,
+    pub decay_rate: f32,
+    pub min_light: f32,
+    pub expire: Duration,
 }
 
 impl Light {
@@ -45,3 +128,10 @@ impl Light {
     }
 }
 
+pub struct Beam {
+    pub entity_id: usize,
+    pub model_id: usize,
+    pub expire: Duration,
+    pub start: Vector3<f32>,
+    pub end: Vector3<f32>,
+}

--- a/src/client/entity/mod.rs
+++ b/src/client/entity/mod.rs
@@ -26,6 +26,8 @@ use cgmath::{Deg, Vector3};
 use chrono::Duration;
 
 pub const MAX_BEAMS: usize = 24;
+pub const MAX_TEMP_ENTITIES: usize = 64;
+pub const MAX_STATIC_ENTITIES: usize = 128;
 
 #[derive(Debug)]
 pub struct ClientEntity {
@@ -128,6 +130,7 @@ impl Light {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct Beam {
     pub entity_id: usize,
     pub model_id: usize,

--- a/src/client/entity/particle.rs
+++ b/src/client/entity/particle.rs
@@ -198,6 +198,14 @@ impl Particle {
             }
         }
     }
+
+    pub fn origin(&self) -> Vector3<f32> {
+        self.origin
+    }
+
+    pub fn color(&self) -> u8 {
+        self.color
+    }
 }
 
 pub enum TrailKind {

--- a/src/client/entity/particle.rs
+++ b/src/client/entity/particle.rs
@@ -485,15 +485,17 @@ impl Particles {
 
         for _ in 0..count {
             let scatter = self.random_vector3(&SCATTER_DISTRIBUTION);
-            let color = color & !7 + COLOR_DISTRIBUTION.sample(&mut self.rng);
+
+            // picks any color in the block of 8 the original color belongs to.
+            // e.g., if the color argument is 17, picks randomly in [16, 23]
+            let color = (color & !7) + COLOR_DISTRIBUTION.sample(&mut self.rng);
+
             let ttl = Duration::milliseconds(TTL_DISTRIBUTION.sample(&mut self.rng));
 
             self.insert(Particle {
                 kind: ParticleKind::Grav,
                 origin: origin + scatter,
                 velocity: 15.0 * direction,
-                // picks any color in the block of 8 the original color belongs to.
-                // e.g., if the color argument is 17, picks randomly in [16, 23]
                 color,
                 spawned: time,
                 expire: time + ttl,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -44,9 +44,9 @@ use std::{
 use crate::{
     client::{
         entity::{
-            particle::{Particles, TrailKind, MAX_PARTICLES},
-            Beam, ClientEntity, LightDesc, Lights, MAX_BEAMS, MAX_LIGHTS, MAX_STATIC_ENTITIES,
-            MAX_TEMP_ENTITIES,
+            particle::{Particle, Particles, TrailKind, MAX_PARTICLES},
+            Beam, ClientEntity, Light, LightDesc, Lights, MAX_BEAMS, MAX_LIGHTS,
+            MAX_STATIC_ENTITIES, MAX_TEMP_ENTITIES,
         },
         input::game::{Action, GameInput},
         sound::{AudioSource, Channel, Listener, StaticSound},
@@ -54,7 +54,6 @@ use crate::{
         view::{IdleVars, KickVars, RollVars, View},
     },
     common::{
-        alloc::LinkedSlab,
         bsp,
         console::{CmdRegistry, Console, CvarRegistry},
         engine,
@@ -1872,6 +1871,14 @@ impl Client {
             .iter()
             .map(move |i| &self.state.entities[*i])
             .chain(self.state.temp_entities.iter())
+    }
+
+    pub fn iter_lights(&self) -> impl Iterator<Item = &Light> {
+        self.state.lights.iter()
+    }
+
+    pub fn iter_particles(&self) -> impl Iterator<Item = &Particle> {
+        self.state.particles.iter()
     }
 
     pub fn register_cmds(&self, cmds: &mut CmdRegistry) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,7 +43,7 @@ use std::{
 
 use crate::{
     client::{
-        entity::particle::{ParticleList, MAX_PARTICLES},
+        entity::particle::{Particles, MAX_PARTICLES},
         input::game::{Action, GameInput},
         sound::{AudioSource, Channel, Listener, StaticSound},
         trace::{TraceEntity, TraceFrame},
@@ -299,7 +299,7 @@ struct ClientState {
     static_entities: Vec<ClientEntity>,
 
     // all active particles
-    particles: ParticleList,
+    particles: Particles,
 
     // visible entities, updated per-frame
     visible_entity_ids: Vec<usize>,
@@ -368,7 +368,7 @@ impl ClientState {
             static_sounds: Vec::new(),
             entities: Vec::new(),
             static_entities: Vec::new(),
-            particles: ParticleList::with_capacity(MAX_PARTICLES),
+            particles: Particles::with_capacity(MAX_PARTICLES),
             visible_entity_ids: Vec::new(),
             light_styles: HashMap::new(),
             stats: [0; MAX_STATS],

--- a/src/client/render/blit.rs
+++ b/src/client/render/blit.rs
@@ -56,12 +56,12 @@ impl BlitPipeline {
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("blit bind group"),
             layout: &bind_group_layouts[0],
-            bindings: &[
-                wgpu::Binding {
+            entries: &[
+                wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::Sampler(&sampler),
                 },
-                wgpu::Binding {
+                wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::TextureView(input),
                 },
@@ -103,6 +103,10 @@ impl BlitPipeline {
 }
 
 impl Pipeline for BlitPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "blit"
     }
@@ -110,7 +114,7 @@ impl Pipeline for BlitPipeline {
     fn bind_group_layout_descriptors() -> Vec<wgpu::BindGroupLayoutDescriptor<'static>> {
         vec![wgpu::BindGroupLayoutDescriptor {
             label: Some("blit bind group"),
-            bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+            entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
         }]
     }
 

--- a/src/client/render/mod.rs
+++ b/src/client/render/mod.rs
@@ -62,7 +62,7 @@ pub use pipeline::Pipeline;
 pub use postprocess::PostProcessRenderer;
 pub use target::{RenderTarget, RenderTargetResolve, SwapChainTarget};
 pub use ui::{hud::HudState, UiOverlay, UiRenderer, UiState};
-pub use world::{Camera, WorldRenderer, deferred::{DeferredRenderer, DeferredUniforms}};
+pub use world::{Camera, WorldRenderer, deferred::{PointLight, DeferredRenderer, DeferredUniforms}};
 
 use std::{
     borrow::Cow,
@@ -94,6 +94,7 @@ use failure::Error;
 const DEPTH_ATTACHMENT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 pub const DIFFUSE_ATTACHMENT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
 const NORMAL_ATTACHMENT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+const LIGHT_ATTACHMENT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
 
 const DIFFUSE_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 const FULLBRIGHT_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;

--- a/src/client/render/mod.rs
+++ b/src/client/render/mod.rs
@@ -62,7 +62,10 @@ pub use pipeline::Pipeline;
 pub use postprocess::PostProcessRenderer;
 pub use target::{RenderTarget, RenderTargetResolve, SwapChainTarget};
 pub use ui::{hud::HudState, UiOverlay, UiRenderer, UiState};
-pub use world::{Camera, WorldRenderer, deferred::{PointLight, DeferredRenderer, DeferredUniforms}};
+pub use world::{
+    deferred::{DeferredRenderer, DeferredUniforms, PointLight},
+    Camera, WorldRenderer,
+};
 
 use std::{
     borrow::Cow,
@@ -81,6 +84,7 @@ use crate::{
             alias::AliasPipeline,
             brush::BrushPipeline,
             deferred::DeferredPipeline,
+            particle::ParticlePipeline,
             postprocess::{self, PostProcessPipeline},
             sprite::SpritePipeline,
             EntityUniforms,
@@ -253,6 +257,7 @@ pub struct GraphicsState {
     brush_pipeline: BrushPipeline,
     sprite_pipeline: SpritePipeline,
     deferred_pipeline: DeferredPipeline,
+    particle_pipeline: ParticlePipeline,
     postprocess_pipeline: PostProcessPipeline,
     glyph_pipeline: GlyphPipeline,
     quad_pipeline: QuadPipeline,
@@ -332,7 +337,7 @@ impl GraphicsState {
             device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("per-frame bind group"),
                 layout: &world_bind_group_layouts[world::BindGroupLayoutId::PerFrame as usize],
-                bindings: &[wgpu::Binding {
+                entries: &[wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer(frame_uniform_buffer.slice(..)),
                 }],
@@ -340,21 +345,21 @@ impl GraphicsState {
             device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("brush per-entity bind group"),
                 layout: &world_bind_group_layouts[world::BindGroupLayoutId::PerEntity as usize],
-                bindings: &[
-                    wgpu::Binding {
+                entries: &[
+                    wgpu::BindGroupEntry {
                         binding: 0,
                         resource: wgpu::BindingResource::Buffer(
                             entity_uniform_buffer
                                 .borrow()
                                 .buffer()
-                                .slice(0..entity_uniform_buffer.borrow().block_size().get()),
+                                .slice(..size_of::<EntityUniforms>() as wgpu::BufferAddress),
                         ),
                     },
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::Sampler(&diffuse_sampler),
                     },
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 2,
                         resource: wgpu::BindingResource::Sampler(&lightmap_sampler),
                     },
@@ -382,6 +387,8 @@ impl GraphicsState {
             sample_count,
         );
         let deferred_pipeline = DeferredPipeline::new(&device, &mut compiler, sample_count);
+        let particle_pipeline =
+            ParticlePipeline::new(&device, &queue, &mut compiler, sample_count, &palette);
         let postprocess_pipeline = PostProcessPipeline::new(&device, &mut compiler, sample_count);
         let quad_pipeline = QuadPipeline::new(&device, &mut compiler, sample_count);
         let glyph_pipeline = GlyphPipeline::new(&device, &mut compiler, sample_count);
@@ -418,6 +425,7 @@ impl GraphicsState {
             brush_pipeline,
             sprite_pipeline,
             deferred_pipeline,
+            particle_pipeline,
             postprocess_pipeline,
             glyph_pipeline,
             quad_pipeline,
@@ -579,6 +587,10 @@ impl GraphicsState {
 
     pub fn deferred_pipeline(&self) -> &DeferredPipeline {
         &self.deferred_pipeline
+    }
+
+    pub fn particle_pipeline(&self) -> &ParticlePipeline {
+        &self.particle_pipeline
     }
 
     pub fn postprocess_pipeline(&self) -> &PostProcessPipeline {

--- a/src/client/render/ui/glyph.rs
+++ b/src/client/render/ui/glyph.rs
@@ -116,6 +116,10 @@ impl GlyphPipeline {
 }
 
 impl Pipeline for GlyphPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "glyph"
     }
@@ -131,7 +135,7 @@ impl Pipeline for GlyphPipeline {
     fn bind_group_layout_descriptors() -> Vec<wgpu::BindGroupLayoutDescriptor<'static>> {
         vec![wgpu::BindGroupLayoutDescriptor {
             label: Some("glyph constant bind group"),
-            bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+            entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
         }]
     }
 
@@ -246,12 +250,12 @@ impl GlyphRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("glyph constant bind group"),
                 layout: &state.glyph_pipeline().bind_group_layouts()[0],
-                bindings: &[
-                    wgpu::Binding {
+                entries: &[
+                    wgpu::BindGroupEntry {
                         binding: 0,
                         resource: wgpu::BindingResource::Sampler(state.diffuse_sampler()),
                     },
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::TextureViewArray(&texture_views[..]),
                     },

--- a/src/client/render/ui/quad.rs
+++ b/src/client/render/ui/quad.rs
@@ -185,6 +185,10 @@ impl QuadPipeline {
 }
 
 impl Pipeline for QuadPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "quad"
     }
@@ -194,17 +198,17 @@ impl Pipeline for QuadPipeline {
             // group 0: per-frame
             wgpu::BindGroupLayoutDescriptor {
                 label: Some("per-frame quad bind group"),
-                bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
             },
             // group 1: per-texture
             wgpu::BindGroupLayoutDescriptor {
                 label: Some("per-texture quad bind group"),
-                bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[1],
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[1],
             },
             // group 2: per-quad
             wgpu::BindGroupLayoutDescriptor {
                 label: Some("per-texture quad bind group"),
-                bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[2],
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[2],
             },
         ]
     }
@@ -285,7 +289,7 @@ impl QuadTexture {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: None,
                 layout: &state.quad_pipeline().bind_group_layouts()[1],
-                bindings: &[wgpu::Binding {
+                entries: &[wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::TextureView(&texture_view),
                 }],
@@ -338,7 +342,7 @@ impl QuadRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("quad sampler bind group"),
                 layout: &state.quad_pipeline().bind_group_layouts()[0],
-                bindings: &[wgpu::Binding {
+                entries: &[wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::Sampler(state.diffuse_sampler()),
                 }],
@@ -348,10 +352,14 @@ impl QuadRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("quad transform bind group"),
                 layout: &state.quad_pipeline().bind_group_layouts()[2],
-                bindings: &[wgpu::Binding {
+                entries: &[wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer(
-                        state.quad_pipeline().uniform_buffer().buffer().slice(..),
+                        state
+                            .quad_pipeline()
+                            .uniform_buffer()
+                            .buffer()
+                            .slice(..size_of::<QuadUniforms>() as wgpu::BufferAddress),
                     ),
                 }],
             });

--- a/src/client/render/world/alias.rs
+++ b/src/client/render/world/alias.rs
@@ -3,7 +3,7 @@ use std::{mem::size_of, ops::Range};
 use crate::{
     client::render::{
         world::BindGroupLayoutId, GraphicsState, Pipeline, TextureData, DEPTH_ATTACHMENT_FORMAT,
-        DIFFUSE_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
+        DIFFUSE_ATTACHMENT_FORMAT, LIGHT_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
     },
     common::{
         mdl::{self, AliasModel},
@@ -125,6 +125,13 @@ impl Pipeline for AliasPipeline {
             // normal attachment
             wgpu::ColorStateDescriptor {
                 format: NORMAL_ATTACHMENT_FORMAT,
+                alpha_blend: wgpu::BlendDescriptor::REPLACE,
+                color_blend: wgpu::BlendDescriptor::REPLACE,
+                write_mask: wgpu::ColorWrite::ALL,
+            },
+            // light attachment
+            wgpu::ColorStateDescriptor {
+                format: LIGHT_ATTACHMENT_FORMAT,
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 color_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,

--- a/src/client/render/world/alias.rs
+++ b/src/client/render/world/alias.rs
@@ -2,8 +2,8 @@ use std::{mem::size_of, ops::Range};
 
 use crate::{
     client::render::{
-        world::BindGroupLayoutId, GraphicsState, Pipeline, TextureData, DEPTH_ATTACHMENT_FORMAT,
-        DIFFUSE_ATTACHMENT_FORMAT, LIGHT_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
+        world::{BindGroupLayoutId, WorldPipelineBase},
+        GraphicsState, Pipeline, TextureData,
     },
     common::{
         mdl::{self, AliasModel},
@@ -77,6 +77,10 @@ impl AliasPipeline {
 }
 
 impl Pipeline for AliasPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "alias"
     }
@@ -94,19 +98,13 @@ impl Pipeline for AliasPipeline {
             // group 2: updated per-texture
             wgpu::BindGroupLayoutDescriptor {
                 label: Some("brush per-texture chain bind group"),
-                bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
             },
         ]
     }
 
     fn rasterization_state_descriptor() -> Option<wgpu::RasterizationStateDescriptor> {
-        Some(wgpu::RasterizationStateDescriptor {
-            front_face: wgpu::FrontFace::Cw,
-            cull_mode: wgpu::CullMode::Back,
-            depth_bias: 0,
-            depth_bias_slope_scale: 0.0,
-            depth_bias_clamp: 0.0,
-        })
+        WorldPipelineBase::rasterization_state_descriptor()
     }
 
     fn primitive_topology() -> wgpu::PrimitiveTopology {
@@ -114,41 +112,11 @@ impl Pipeline for AliasPipeline {
     }
 
     fn color_state_descriptors() -> Vec<wgpu::ColorStateDescriptor> {
-        vec![
-            // diffuse attachment
-            wgpu::ColorStateDescriptor {
-                format: DIFFUSE_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-            // normal attachment
-            wgpu::ColorStateDescriptor {
-                format: NORMAL_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-            // light attachment
-            wgpu::ColorStateDescriptor {
-                format: LIGHT_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-        ]
+        WorldPipelineBase::color_state_descriptors()
     }
 
     fn depth_stencil_state_descriptor() -> Option<wgpu::DepthStencilStateDescriptor> {
-        Some(wgpu::DepthStencilStateDescriptor {
-            format: DEPTH_ATTACHMENT_FORMAT,
-            depth_write_enabled: true,
-            depth_compare: wgpu::CompareFunction::LessEqual,
-            stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-            stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-            stencil_read_mask: 0,
-            stencil_write_mask: 0,
-        })
+        WorldPipelineBase::depth_stencil_state_descriptor()
     }
 
     // NOTE: if the vertex format is changed, this descriptor must also be changed accordingly.
@@ -377,7 +345,7 @@ impl AliasRenderer {
                             // TODO: per-pipeline bind group layout ids
                             layout: &state.alias_pipeline().bind_group_layouts()
                                 [BindGroupLayoutId::PerTexture as usize - 2],
-                            bindings: &[wgpu::Binding {
+                            entries: &[wgpu::BindGroupEntry {
                                 binding: 0,
                                 resource: wgpu::BindingResource::TextureView(&diffuse_view),
                             }],
@@ -411,7 +379,7 @@ impl AliasRenderer {
                                     label: None,
                                     layout: &state.alias_pipeline().bind_group_layouts()
                                         [BindGroupLayoutId::PerTexture as usize - 2],
-                                    bindings: &[wgpu::Binding {
+                                    entries: &[wgpu::BindGroupEntry {
                                         binding: 0,
                                         resource: wgpu::BindingResource::TextureView(&diffuse_view),
                                     }],

--- a/src/client/render/world/brush.rs
+++ b/src/client/render/world/brush.rs
@@ -26,7 +26,7 @@ use crate::{
         warp,
         world::BindGroupLayoutId,
         Camera, GraphicsState, LightmapData, Pipeline, TextureData, DEPTH_ATTACHMENT_FORMAT,
-        DIFFUSE_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
+        DIFFUSE_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT, LIGHT_ATTACHMENT_FORMAT,
     },
     common::{
         bsp::{BspData, BspFace, BspLeaf, BspModel, BspTexInfo, BspTextureMipmap},
@@ -222,6 +222,13 @@ impl Pipeline for BrushPipeline {
             // normal attachment
             wgpu::ColorStateDescriptor {
                 format: NORMAL_ATTACHMENT_FORMAT,
+                alpha_blend: wgpu::BlendDescriptor::REPLACE,
+                color_blend: wgpu::BlendDescriptor::REPLACE,
+                write_mask: wgpu::ColorWrite::ALL,
+            },
+            // light attachment
+            wgpu::ColorStateDescriptor {
+                format: LIGHT_ATTACHMENT_FORMAT,
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 color_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,

--- a/src/client/render/world/deferred.rs
+++ b/src/client/render/world/deferred.rs
@@ -1,9 +1,12 @@
 use std::{mem::size_of, num::NonZeroU64};
 
-use cgmath::{Matrix4, SquareMatrix};
+use cgmath::{Matrix4, SquareMatrix as _, Vector3, Zero as _};
 
 use crate::{
-    client::render::{pipeline::Pipeline, ui::quad::QuadPipeline, GraphicsState},
+    client::{
+        entity::MAX_LIGHTS,
+        render::{pipeline::Pipeline, ui::quad::QuadPipeline, GraphicsState},
+    },
     common::util::any_as_bytes,
 };
 
@@ -39,7 +42,7 @@ lazy_static! {
                 },
             ),
 
-            // depth buffer
+            // light buffer
             wgpu::BindGroupLayoutEntry::new(
                 3,
                 wgpu::ShaderStage::FRAGMENT,
@@ -50,9 +53,20 @@ lazy_static! {
                 },
             ),
 
-            // uniform buffer
+            // depth buffer
             wgpu::BindGroupLayoutEntry::new(
                 4,
+                wgpu::ShaderStage::FRAGMENT,
+                wgpu::BindingType::SampledTexture {
+                    dimension: wgpu::TextureViewDimension::D2,
+                    component_type: wgpu::TextureComponentType::Float,
+                    multisampled: true,
+                },
+            ),
+
+            // uniform buffer
+            wgpu::BindGroupLayoutEntry::new(
+                5,
                 wgpu::ShaderStage::FRAGMENT,
                 wgpu::BindingType::UniformBuffer {
                     dynamic: false,
@@ -65,10 +79,20 @@ lazy_static! {
     ];
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct PointLight {
+    pub origin: Vector3<f32>,
+    pub radius: f32,
+}
+
 #[repr(C, align(256))]
 #[derive(Clone, Copy, Debug)]
 pub struct DeferredUniforms {
     pub inv_projection: [[f32; 4]; 4],
+    pub light_count: u32,
+    pub _pad: [u32; 3],
+    pub lights: [PointLight; MAX_LIGHTS],
 }
 
 pub struct DeferredPipeline {
@@ -89,6 +113,12 @@ impl DeferredPipeline {
             unsafe {
                 any_as_bytes(&DeferredUniforms {
                     inv_projection: Matrix4::identity().into(),
+                    light_count: 0,
+                    _pad: [0; 3],
+                    lights: [PointLight {
+                        origin: Vector3::zero(),
+                        radius: 0.0,
+                    }; MAX_LIGHTS],
                 })
             },
             wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
@@ -181,6 +211,7 @@ impl DeferredRenderer {
         state: &GraphicsState,
         diffuse_buffer: &wgpu::TextureView,
         normal_buffer: &wgpu::TextureView,
+        light_buffer: &wgpu::TextureView,
         depth_buffer: &wgpu::TextureView,
     ) -> DeferredRenderer {
         let bind_group = state
@@ -204,14 +235,19 @@ impl DeferredRenderer {
                         binding: 2,
                         resource: wgpu::BindingResource::TextureView(normal_buffer),
                     },
-                    // depth buffer
+                    // light buffer
                     wgpu::Binding {
                         binding: 3,
+                        resource: wgpu::BindingResource::TextureView(light_buffer),
+                    },
+                    // depth buffer
+                    wgpu::Binding {
+                        binding: 4,
                         resource: wgpu::BindingResource::TextureView(depth_buffer),
                     },
                     // uniform buffer
                     wgpu::Binding {
-                        binding: 4,
+                        binding: 5,
                         resource: wgpu::BindingResource::Buffer(
                             state.deferred_pipeline().uniform_buffer().slice(..),
                         ),

--- a/src/client/render/world/deferred.rs
+++ b/src/client/render/world/deferred.rs
@@ -156,6 +156,10 @@ impl DeferredPipeline {
 }
 
 impl Pipeline for DeferredPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "deferred"
     }
@@ -163,7 +167,7 @@ impl Pipeline for DeferredPipeline {
     fn bind_group_layout_descriptors() -> Vec<wgpu::BindGroupLayoutDescriptor<'static>> {
         vec![wgpu::BindGroupLayoutDescriptor {
             label: Some("deferred bind group"),
-            bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+            entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
         }]
     }
 
@@ -219,34 +223,34 @@ impl DeferredRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("deferred bind group"),
                 layout: &state.deferred_pipeline().bind_group_layouts()[0],
-                bindings: &[
+                entries: &[
                     // sampler
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 0,
                         resource: wgpu::BindingResource::Sampler(state.diffuse_sampler()),
                     },
                     // diffuse buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::TextureView(diffuse_buffer),
                     },
                     // normal buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 2,
                         resource: wgpu::BindingResource::TextureView(normal_buffer),
                     },
                     // light buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::TextureView(light_buffer),
                     },
                     // depth buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 4,
                         resource: wgpu::BindingResource::TextureView(depth_buffer),
                     },
                     // uniform buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 5,
                         resource: wgpu::BindingResource::Buffer(
                             state.deferred_pipeline().uniform_buffer().slice(..),

--- a/src/client/render/world/particle.rs
+++ b/src/client/render/world/particle.rs
@@ -1,0 +1,354 @@
+use std::mem::size_of;
+
+use crate::{
+    client::{
+        entity::particle::Particle,
+        render::{
+            create_texture,
+            pipeline::Pipeline,
+            world::{Camera, WorldPipelineBase},
+            Palette, TextureData,
+        },
+    },
+    common::{math::Angles, util::any_slice_as_bytes},
+};
+
+use bumpalo::Bump;
+use cgmath::Matrix4;
+
+lazy_static! {
+    static ref BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS: [Vec<wgpu::BindGroupLayoutEntry>; 1] = [
+        vec![
+            wgpu::BindGroupLayoutEntry::new(
+                0,
+                wgpu::ShaderStage::FRAGMENT,
+                wgpu::BindingType::Sampler { comparison: false },
+            ),
+            // per-index texture array
+            wgpu::BindGroupLayoutEntry {
+                count: Some(256),
+                ..wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::SampledTexture {
+                        dimension: wgpu::TextureViewDimension::D2,
+                        component_type: wgpu::TextureComponentType::Float,
+                        multisampled: false,
+                    },
+                )
+            },
+        ]
+    ];
+
+    static ref VERTEX_BUFFER_DESCRIPTOR_ATTRIBUTES: [Vec<wgpu::VertexAttributeDescriptor>; 2] = [
+        wgpu::vertex_attr_array![
+            // position
+            0 => Float3,
+            // texcoord
+            1 => Float2,
+        ].to_vec(),
+        wgpu::vertex_attr_array![
+            // instance color (index)
+            2 => Uint,
+        ].to_vec(),
+    ];
+}
+
+#[rustfmt::skip]
+const PARTICLE_TEXTURE_PIXELS: [u8; 64] = [
+    0, 0, 1, 1, 1, 1, 0, 0,
+    0, 1, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 0,
+    0, 0, 1, 1, 1, 1, 0, 0,
+];
+
+pub struct ParticlePipeline {
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layouts: Vec<wgpu::BindGroupLayout>,
+    vertex_buffer: wgpu::Buffer,
+    sampler: wgpu::Sampler,
+    textures: Vec<wgpu::Texture>,
+    texture_views: Vec<wgpu::TextureView>,
+    bind_group: wgpu::BindGroup,
+}
+
+impl ParticlePipeline {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        compiler: &mut shaderc::Compiler,
+        sample_count: u32,
+        palette: &Palette,
+    ) -> ParticlePipeline {
+        let (pipeline, bind_group_layouts) =
+            ParticlePipeline::create(device, compiler, &[], sample_count);
+
+        let vertex_buffer = device.create_buffer_with_data(
+            unsafe { any_slice_as_bytes(&VERTICES) },
+            wgpu::BufferUsage::VERTEX,
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("particle sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            lod_min_clamp: -1000.0,
+            lod_max_clamp: 1000.0,
+            compare: None,
+            anisotropy_clamp: Some(16),
+        });
+
+        let textures: Vec<wgpu::Texture> = (0..256)
+            .map(|i| {
+                let mut pixels = PARTICLE_TEXTURE_PIXELS;
+
+                // set up palette translation
+                for pix in pixels.iter_mut() {
+                    if *pix == 0 {
+                        *pix = 0xFF;
+                    } else {
+                        *pix *= i as u8;
+                    }
+                }
+
+                let (diffuse_data, _) = palette.translate(&pixels);
+
+                create_texture(
+                    device,
+                    queue,
+                    Some(&format!("particle texture {}", i)),
+                    8,
+                    8,
+                    &TextureData::Diffuse(diffuse_data),
+                )
+            })
+            .collect();
+        let texture_views: Vec<wgpu::TextureView> =
+            textures.iter().map(|t| t.create_default_view()).collect();
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("particle bind group"),
+            layout: &bind_group_layouts[0],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureViewArray(&texture_views[..]),
+                },
+            ],
+        });
+
+        ParticlePipeline {
+            pipeline,
+            bind_group_layouts,
+            sampler,
+            textures,
+            texture_views,
+            bind_group,
+            vertex_buffer,
+        }
+    }
+
+    pub fn rebuild(
+        &mut self,
+        device: &wgpu::Device,
+        compiler: &mut shaderc::Compiler,
+        sample_count: u32,
+    ) {
+        let layout_refs: Vec<_> = self.bind_group_layouts.iter().collect();
+        self.pipeline = ParticlePipeline::recreate(device, compiler, &layout_refs, sample_count);
+    }
+
+    pub fn pipeline(&self) -> &wgpu::RenderPipeline {
+        &self.pipeline
+    }
+
+    pub fn bind_group_layouts(&self) -> &[wgpu::BindGroupLayout] {
+        &self.bind_group_layouts
+    }
+
+    pub fn vertex_buffer(&self) -> &wgpu::Buffer {
+        &self.vertex_buffer
+    }
+
+    pub fn record_draw<'a, 'b, P>(
+        &'a self,
+        pass: &mut wgpu::RenderPass<'a>,
+        bump: &'a Bump,
+        camera: &Camera,
+        particles: P,
+    ) where
+        P: Iterator<Item = &'b Particle>,
+    {
+        pass.set_pipeline(self.pipeline());
+        pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        pass.set_bind_group(0, &self.bind_group, &[]);
+
+        // face toward camera
+        let Angles { pitch, yaw, roll } = camera.angles();
+        let rotation = Angles {
+            pitch: -pitch,
+            yaw: -yaw,
+            roll: -roll,
+        }
+        .mat4_wgpu();
+
+        for particle in particles {
+            let q_origin = particle.origin();
+            let translation =
+                Matrix4::from_translation([-q_origin.y, q_origin.z, -q_origin.x].into());
+            Self::set_push_constants(
+                pass,
+                Some(bump.alloc(VertexPushConstants {
+                    transform: camera.view_projection() * translation * rotation,
+                })),
+                None,
+                Some(bump.alloc(FragmentPushConstants {
+                    color: particle.color() as u32,
+                })),
+            );
+
+            pass.draw(0..6, 0..1);
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct VertexPushConstants {
+    pub transform: Matrix4<f32>,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct FragmentPushConstants {
+    pub color: u32,
+}
+
+impl Pipeline for ParticlePipeline {
+    type VertexPushConstants = VertexPushConstants;
+    type SharedPushConstants = ();
+    type FragmentPushConstants = FragmentPushConstants;
+
+    fn name() -> &'static str {
+        "particle"
+    }
+
+    fn vertex_shader() -> &'static str {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/shaders/particle.vert"
+        ))
+    }
+
+    fn fragment_shader() -> &'static str {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/shaders/particle.frag"
+        ))
+    }
+
+    // NOTE: if any of the binding indices are changed, they must also be changed in
+    // the corresponding shaders and the BindGroupLayout generation functions.
+    fn bind_group_layout_descriptors() -> Vec<wgpu::BindGroupLayoutDescriptor<'static>> {
+        vec![
+            // group 0
+            wgpu::BindGroupLayoutDescriptor {
+                label: Some("particle bind group layout"),
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+            },
+        ]
+    }
+
+    fn rasterization_state_descriptor() -> Option<wgpu::RasterizationStateDescriptor> {
+        WorldPipelineBase::rasterization_state_descriptor()
+    }
+
+    fn primitive_topology() -> wgpu::PrimitiveTopology {
+        wgpu::PrimitiveTopology::TriangleList
+    }
+
+    fn color_state_descriptors() -> Vec<wgpu::ColorStateDescriptor> {
+        WorldPipelineBase::color_state_descriptors()
+    }
+
+    fn depth_stencil_state_descriptor() -> Option<wgpu::DepthStencilStateDescriptor> {
+        let mut desc = WorldPipelineBase::depth_stencil_state_descriptor().unwrap();
+        desc.depth_write_enabled = false;
+        Some(desc)
+    }
+
+    // NOTE: if the vertex format is changed, this descriptor must also be changed accordingly.
+    fn vertex_buffer_descriptors() -> Vec<wgpu::VertexBufferDescriptor<'static>> {
+        vec![
+            wgpu::VertexBufferDescriptor {
+                stride: size_of::<ParticleVertex>() as u64,
+                step_mode: wgpu::InputStepMode::Vertex,
+                attributes: &wgpu::vertex_attr_array![
+                    // position
+                    0 => Float3,
+                    // texcoord
+                    1 => Float2,
+                ],
+            },
+            wgpu::VertexBufferDescriptor {
+                stride: size_of::<ParticleInstance>() as u64,
+                step_mode: wgpu::InputStepMode::Instance,
+                attributes: &wgpu::vertex_attr_array![
+                    // instance position
+                    2 => Float3,
+                    // color index
+                    3 => Uint,
+                ],
+            },
+        ]
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct ParticleVertex {
+    position: [f32; 3],
+    texcoord: [f32; 2],
+}
+
+pub const VERTICES: [ParticleVertex; 6] = [
+    ParticleVertex {
+        position: [-1.0, -1.0, 0.0],
+        texcoord: [0.0, 1.0],
+    },
+    ParticleVertex {
+        position: [-1.0, 1.0, 0.0],
+        texcoord: [0.0, 0.0],
+    },
+    ParticleVertex {
+        position: [1.0, 1.0, 0.0],
+        texcoord: [1.0, 0.0],
+    },
+    ParticleVertex {
+        position: [-1.0, -1.0, 0.0],
+        texcoord: [0.0, 1.0],
+    },
+    ParticleVertex {
+        position: [1.0, 1.0, 0.0],
+        texcoord: [1.0, 0.0],
+    },
+    ParticleVertex {
+        position: [1.0, -1.0, 0.0],
+        texcoord: [1.0, 1.0],
+    },
+];
+
+#[repr(C)]
+pub struct ParticleInstance {
+    color: u32,
+}

--- a/src/client/render/world/postprocess.rs
+++ b/src/client/render/world/postprocess.rs
@@ -102,6 +102,10 @@ impl PostProcessPipeline {
 }
 
 impl Pipeline for PostProcessPipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "postprocess"
     }
@@ -109,7 +113,7 @@ impl Pipeline for PostProcessPipeline {
     fn bind_group_layout_descriptors() -> Vec<wgpu::BindGroupLayoutDescriptor<'static>> {
         vec![wgpu::BindGroupLayoutDescriptor {
             label: Some("postprocess bind group"),
-            bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+            entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
         }]
     }
 
@@ -159,20 +163,20 @@ impl PostProcessRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("postprocess bind group"),
                 layout: &state.postprocess_pipeline().bind_group_layouts()[0],
-                bindings: &[
+                entries: &[
                     // sampler
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 0,
                         // TODO: might need a dedicated sampler if downsampling
                         resource: wgpu::BindingResource::Sampler(state.diffuse_sampler()),
                     },
                     // color buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::TextureView(color_buffer),
                     },
                     // uniform buffer
-                    wgpu::Binding {
+                    wgpu::BindGroupEntry {
                         binding: 2,
                         resource: wgpu::BindingResource::Buffer(
                             state.postprocess_pipeline().uniform_buffer().slice(..),

--- a/src/client/render/world/sprite.rs
+++ b/src/client/render/world/sprite.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     client::render::{
         world::BindGroupLayoutId, GraphicsState, Pipeline, TextureData, DEPTH_ATTACHMENT_FORMAT,
-        DIFFUSE_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
+        DIFFUSE_ATTACHMENT_FORMAT, LIGHT_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
     },
     common::{
         sprite::{SpriteFrame, SpriteKind, SpriteModel, SpriteSubframe},
@@ -149,6 +149,13 @@ impl Pipeline for SpritePipeline {
             },
             wgpu::ColorStateDescriptor {
                 format: NORMAL_ATTACHMENT_FORMAT,
+                alpha_blend: wgpu::BlendDescriptor::REPLACE,
+                color_blend: wgpu::BlendDescriptor::REPLACE,
+                write_mask: wgpu::ColorWrite::ALL,
+            },
+            // light attachment
+            wgpu::ColorStateDescriptor {
+                format: LIGHT_ATTACHMENT_FORMAT,
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 color_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,

--- a/src/client/render/world/sprite.rs
+++ b/src/client/render/world/sprite.rs
@@ -2,8 +2,8 @@ use std::mem::size_of;
 
 use crate::{
     client::render::{
-        world::BindGroupLayoutId, GraphicsState, Pipeline, TextureData, DEPTH_ATTACHMENT_FORMAT,
-        DIFFUSE_ATTACHMENT_FORMAT, LIGHT_ATTACHMENT_FORMAT, NORMAL_ATTACHMENT_FORMAT,
+        world::{BindGroupLayoutId, WorldPipelineBase},
+        GraphicsState, Pipeline, TextureData,
     },
     common::{
         sprite::{SpriteFrame, SpriteKind, SpriteModel, SpriteSubframe},
@@ -101,6 +101,10 @@ impl SpritePipeline {
 }
 
 impl Pipeline for SpritePipeline {
+    type VertexPushConstants = ();
+    type SharedPushConstants = ();
+    type FragmentPushConstants = ();
+
     fn name() -> &'static str {
         "sprite"
     }
@@ -120,19 +124,13 @@ impl Pipeline for SpritePipeline {
             // group 2: updated per-texture
             wgpu::BindGroupLayoutDescriptor {
                 label: Some("sprite per-texture chain bind group"),
-                bindings: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
+                entries: &BIND_GROUP_LAYOUT_DESCRIPTOR_BINDINGS[0],
             },
         ]
     }
 
     fn rasterization_state_descriptor() -> Option<wgpu::RasterizationStateDescriptor> {
-        Some(wgpu::RasterizationStateDescriptor {
-            front_face: wgpu::FrontFace::Cw,
-            cull_mode: wgpu::CullMode::None,
-            depth_bias: 0,
-            depth_bias_slope_scale: 0.0,
-            depth_bias_clamp: 0.0,
-        })
+        WorldPipelineBase::rasterization_state_descriptor()
     }
 
     fn primitive_topology() -> wgpu::PrimitiveTopology {
@@ -140,39 +138,11 @@ impl Pipeline for SpritePipeline {
     }
 
     fn color_state_descriptors() -> Vec<wgpu::ColorStateDescriptor> {
-        vec![
-            wgpu::ColorStateDescriptor {
-                format: DIFFUSE_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-            wgpu::ColorStateDescriptor {
-                format: NORMAL_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-            // light attachment
-            wgpu::ColorStateDescriptor {
-                format: LIGHT_ATTACHMENT_FORMAT,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            },
-        ]
+        WorldPipelineBase::color_state_descriptors()
     }
 
     fn depth_stencil_state_descriptor() -> Option<wgpu::DepthStencilStateDescriptor> {
-        Some(wgpu::DepthStencilStateDescriptor {
-            format: DEPTH_ATTACHMENT_FORMAT,
-            depth_write_enabled: true,
-            depth_compare: wgpu::CompareFunction::LessEqual,
-            stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-            stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-            stencil_read_mask: 0,
-            stencil_write_mask: 0,
-        })
+        WorldPipelineBase::depth_stencil_state_descriptor()
     }
 
     // NOTE: if the vertex format is changed, this descriptor must also be changed accordingly.
@@ -273,7 +243,7 @@ impl Frame {
                     label: None,
                     layout: &state.sprite_pipeline().bind_group_layouts()
                         [BindGroupLayoutId::PerTexture as usize - 2],
-                    bindings: &[wgpu::Binding {
+                    entries: &[wgpu::BindGroupEntry {
                         binding: 0,
                         resource: wgpu::BindingResource::TextureView(&diffuse_view),
                     }],

--- a/src/common/alloc.rs
+++ b/src/common/alloc.rs
@@ -1,0 +1,174 @@
+use std::{collections::LinkedList, mem};
+
+use slab::Slab;
+
+/// A slab allocator with a linked list of allocations.
+///
+/// This allocator trades O(1) random access by key, a property of
+/// [`Slab`](slab::Slab), for the ability to iterate only those entries that are
+/// actually allocated. This significantly reduces the cost of `retain()`: where
+/// `Slab::retain` is O(capacity) regardless of how many values are allocated,
+/// [`LinkedSlab::retain`](LinkedSlab::retain) is O(n) in the number of values.
+pub struct LinkedSlab<T> {
+    slab: Slab<T>,
+    allocated: LinkedList<usize>,
+}
+
+impl<T> LinkedSlab<T> {
+    /// Construct a new, empty `LinkedSlab` with the specified capacity.
+    ///
+    /// The returned allocator will be able to store exactly `capacity` without
+    /// reallocating. If `capacity` is 0, the slab will not allocate.
+    pub fn with_capacity(capacity: usize) -> LinkedSlab<T> {
+        LinkedSlab {
+            slab: Slab::with_capacity(capacity),
+            allocated: LinkedList::new(),
+        }
+    }
+
+    /// Return the number of values the allocator can store without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.slab.capacity()
+    }
+
+    /// Clear the allocator of all values.
+    pub fn clear(&mut self) {
+        self.allocated.clear();
+        self.slab.clear();
+    }
+
+    /// Return the number of stored values.
+    pub fn len(&self) -> usize {
+        self.slab.len()
+    }
+
+    /// Return `true` if there are no values allocated.
+    pub fn is_empty(&self) -> bool {
+        self.slab.is_empty()
+    }
+
+    /// Return an iterator over the allocated values.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.allocated
+            .iter()
+            .map(move |key| self.slab.get(*key).unwrap())
+    }
+
+    /// Return a reference to the value associated with the given key.
+    ///
+    /// If the given key is not associated with a value, then None is returned.
+    pub fn get(&self, key: usize) -> Option<&T> {
+        self.slab.get(key)
+    }
+
+    /// Return a mutable reference to the value associated with the given key.
+    ///
+    /// If the given key is not associated with a value, then None is returned.
+    pub fn get_mut(&mut self, key: usize) -> Option<&mut T> {
+        self.slab.get_mut(key)
+    }
+
+    /// Allocate a value, returning the key assigned to the value.
+    ///
+    /// This operation is O(1).
+    pub fn insert(&mut self, val: T) -> usize {
+        let key = self.slab.insert(val);
+        self.allocated.push_front(key);
+        key
+    }
+
+    /// Remove and return the value associated with the given key.
+    ///
+    /// The key is then released and may be associated with future stored values.
+    ///
+    /// Note that this operation is O(n) in the number of allocated values.
+    pub fn remove(&mut self, key: usize) -> T {
+        self.allocated.drain_filter(|k| *k == key);
+        self.slab.remove(key)
+    }
+
+    /// Return `true` if a value is associated with the given key.
+    pub fn contains(&self, key: usize) -> bool {
+        self.slab.contains(key)
+    }
+
+    /// Retain only the elements specified by the predicate.
+    ///
+    /// The predicate is permitted to modify allocated values in-place.
+    ///
+    /// This operation is O(n) in the number of allocated values.
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(usize, &mut T) -> bool,
+    {
+        // move contents out to avoid double mutable borrow of self.
+        // neither LinkedList::new() nor Slab::new() allocates any memory, so
+        // this is free.
+        let mut allocated = mem::replace(&mut self.allocated, LinkedList::new());
+        let mut slab = mem::replace(&mut self.slab, Slab::new());
+
+        allocated.drain_filter(|k| {
+            let retain = match slab.get_mut(*k) {
+                Some(ref mut v) => f(*k, v),
+                None => true,
+            };
+
+            if !retain {
+                slab.remove(*k);
+            }
+
+            !retain
+        });
+
+        // put them back
+        self.slab = slab;
+        self.allocated = allocated;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{collections::HashSet, iter::FromIterator as _};
+
+    #[test]
+    fn test_iter() {
+        let values: Vec<i32> = vec![1, 3, 5, 7, 11, 13, 17, 19];
+
+        let mut linked_slab = LinkedSlab::with_capacity(values.len());
+        let mut expected = HashSet::new();
+
+        for value in values.iter() {
+            linked_slab.insert(*value);
+            expected.insert(*value);
+        }
+
+        let mut actual = HashSet::new();
+        for value in linked_slab.iter() {
+            actual.insert(*value);
+        }
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_retain() {
+        let mut values: Vec<i32> = vec![0, 9, 1, 8, 2, 7, 3, 6, 4, 5];
+
+        let mut linked_slab = LinkedSlab::with_capacity(values.len());
+
+        for value in values.iter() {
+            linked_slab.insert(*value);
+        }
+
+        values.retain(|v| v % 2 == 0);
+        let mut expected: HashSet<i32> = HashSet::from_iter(values.into_iter());
+
+        linked_slab.retain(|_, v| *v % 2 == 0);
+
+        let mut actual = HashSet::from_iter(linked_slab.iter().map(|v| *v));
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+pub mod alloc;
 pub mod bsp;
 pub mod console;
 pub mod engine;

--- a/src/common/net/mod.rs
+++ b/src/common/net/mod.rs
@@ -331,6 +331,7 @@ pub enum TempEntity {
     },
     Beam {
         kind: BeamEntityKind,
+        entity_id: i16,
         start: Vector3<f32>,
         end: Vector3<f32>,
     },
@@ -401,11 +402,13 @@ impl TempEntity {
                         _ => unreachable!(),
                     },
                 },
+                entity_id: reader.read_i16::<LittleEndian>()?,
                 start: read_coord_vector3(reader)?,
                 end: read_coord_vector3(reader)?,
             },
             Code::Grapple => Beam {
                 kind: BeamEntityKind::Grapple,
+                entity_id: reader.read_i16::<LittleEndian>()?,
                 start: read_coord_vector3(reader)?,
                 end: read_coord_vector3(reader)?,
             },
@@ -461,7 +464,7 @@ impl TempEntity {
                 write_coord_vector3(writer, origin)?;
             }
 
-            TempEntity::Beam { kind, start, end } => {
+            TempEntity::Beam { kind, entity_id, start, end } => {
                 let code = match kind {
                     BeamEntityKind::Lightning { model_id } => match model_id {
                         1 => Code::Lightning1,
@@ -472,6 +475,7 @@ impl TempEntity {
                     },
                     BeamEntityKind::Grapple => Code::Grapple,
                 };
+                writer.write_i16::<LittleEndian>(entity_id)?;
                 writer.write_u8(code as u8)?;
                 write_coord_vector3(writer, start)?;
                 write_coord_vector3(writer, end)?;

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -37,15 +37,35 @@ where
     String::from_utf8(bytes)
 }
 
-pub unsafe fn any_as_bytes<T>(t: &T) -> &[u8] where T: Pod {
+pub unsafe fn any_as_bytes<T>(t: &T) -> &[u8]
+where
+    T: Pod,
+{
     std::slice::from_raw_parts((t as *const T) as *const u8, size_of::<T>())
 }
 
-pub unsafe fn any_slice_as_bytes<T>(t: &[T]) -> &[u8] where T: Pod {
+pub unsafe fn any_slice_as_bytes<T>(t: &[T]) -> &[u8]
+where
+    T: Pod,
+{
     std::slice::from_raw_parts(t.as_ptr() as *const u8, size_of::<T>() * t.len())
 }
 
-pub unsafe fn bytes_as_any<T>(bytes: &[u8]) -> T where T: Pod {
+pub unsafe fn bytes_as_any<T>(bytes: &[u8]) -> T
+where
+    T: Pod,
+{
     assert_eq!(bytes.len(), size_of::<T>());
     std::ptr::read_unaligned(bytes.as_ptr() as *const T)
+}
+
+pub unsafe fn any_as_u32_slice<T>(t: &T) -> &[u32]
+where
+    T: Pod,
+{
+    assert!(size_of::<T>() % size_of::<u32>() == 0);
+    std::slice::from_raw_parts(
+        (t as *const T) as *const u32,
+        size_of::<T>() / size_of::<u32>(),
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #![deny(unused_must_use)]
-#![feature(clamp, const_nonzero_int_methods)]
+#![feature(clamp, const_nonzero_int_methods, drain_filter)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
### Dynamic Lighting

The initial geometry pass now writes lightmaps to a separate light attachment. The deferred pass blends dynamic point lights with the value sampled from the light attachment when calculating the light level for the output.

Below: RenderDoc view of the deferred pass output. The diffuse color, normal and light input buffers are on the right.

![richter-deferred-renderdoc](https://user-images.githubusercontent.com/5809282/87823648-64ea7700-c839-11ea-8db5-e8cab3e88d77.png)


### Particle Rendering

This includes rocket and grenade trails, explosions, projectile and gunshot impacts, and gib blood trails.

Below: in the right half of the image, particles from a rocket explosion and the smoke trail of a second rocket.

![richter-2020-07-17T19-20-24](https://user-images.githubusercontent.com/5809282/87827323-505dad00-c840-11ea-8bdf-09c95859f054.png)
