### PR TITLE
Rendering improvements

### DIFF
--- a/shaders/brush.frag
+++ b/shaders/brush.frag
@@ -14,6 +14,10 @@ layout(location = 1) in vec2 f_diffuse; // also used for fullbright
 layout(location = 2) in vec2 f_lightmap;
 flat layout(location = 3) in uvec4 f_lightmap_anim;
 
+layout(push_constant) uniform PushConstants {
+  layout(offset = 128) uint texture_kind;
+} push_constants;
+
 // set 0: per-frame
 layout(set = 0, binding = 0) uniform FrameUniforms {
     float light_anim_frames[64];
@@ -58,7 +62,7 @@ vec4 calc_light() {
 }
 
 void main() {
-    switch (texture_uniforms.kind) {
+    switch (push_constants.texture_kind) {
         case TEXTURE_KIND_REGULAR:
             diffuse_attachment = texture(
                 sampler2D(u_diffuse_texture, u_diffuse_sampler),

--- a/shaders/brush.frag
+++ b/shaders/brush.frag
@@ -16,7 +16,7 @@ flat layout(location = 3) in uvec4 f_lightmap_anim;
 
 // set 0: per-frame
 layout(set = 0, binding = 0) uniform FrameUniforms {
-    uint light_anim_frames[64]; // range [0, 550]
+    float light_anim_frames[64];
     vec4 camera_pos;
     float time;
     bool r_lightmap;
@@ -40,19 +40,21 @@ layout(location = 0) out vec4 diffuse_attachment;
 layout(location = 1) out vec4 normal_attachment;
 layout(location = 2) out vec4 light_attachment;
 
-float calc_light() {
-    float light = 0.0;
+vec4 calc_light() {
+    vec4 light = vec4(0.0, 0.0, 0.0, 0.0);
     for (int i = 0; i < 4 && f_lightmap_anim[i] != LIGHTMAP_ANIM_END; i++) {
-        uint umap = uint(texture(
+        float map = texture(
             sampler2D(u_lightmap_texture[i], u_lightmap_sampler),
             f_lightmap
-        ).r * 255.0) * 2;
-        uint ustyle = frame_uniforms.light_anim_frames[f_lightmap_anim[i]];
-        uint ulight = umap * ustyle;
-        light += float(min(ulight >> 8, 255)) / 256.0;
+        ).r;
+
+        // range [0, 2]
+        float style = frame_uniforms.light_anim_frames[f_lightmap_anim[i]];
+        light[i] = map * style;
     }
 
-    return light.r;
+    // scale by half so values don't get clamped
+    return light / 2.0;
 }
 
 void main() {
@@ -71,8 +73,7 @@ void main() {
             if (fullbright != 0.0) {
                 light_attachment = vec4(1.0, 1.0, 1.0, 1.0);
             } else {
-                float light = calc_light();
-                light_attachment = vec4(light, light, light, 1.0);
+                light_attachment = calc_light();
             }
             break;
 

--- a/shaders/brush.vert
+++ b/shaders/brush.vert
@@ -13,6 +13,7 @@ layout(location = 4) in uvec4 a_lightmap_anim;
 layout(push_constant) uniform PushConstants {
   mat4 transform;
   mat4 model_view;
+  uint texture_kind;
 } push_constants;
 
 layout(location = 0) out vec3 f_normal;
@@ -26,17 +27,13 @@ layout(set = 0, binding = 0) uniform FrameUniforms {
     float time;
 } frame_uniforms;
 
-layout(set = 2, binding = 2) uniform TextureUniforms {
-    uint kind;
-} texture_uniforms;
-
 // convert from Quake coordinates
 vec3 convert(vec3 from) {
   return vec3(-from.y, from.z, -from.x);
 }
 
 void main() {
-    if (texture_uniforms.kind == TEXTURE_KIND_SKY) {
+    if (push_constants.texture_kind == TEXTURE_KIND_SKY) {
         vec3 dir = a_position - frame_uniforms.camera_pos.xyz;
         dir.z *= 3.0;
 

--- a/shaders/brush.vert
+++ b/shaders/brush.vert
@@ -12,7 +12,7 @@ layout(location = 4) in uvec4 a_lightmap_anim;
 
 layout(push_constant) uniform PushConstants {
   mat4 transform;
-  mat4 model;
+  mat4 model_view;
 } push_constants;
 
 layout(location = 0) out vec3 f_normal;
@@ -48,7 +48,7 @@ void main() {
         f_diffuse = a_diffuse;
     }
 
-    f_normal = mat3(transpose(inverse(push_constants.model))) * convert(a_normal);
+    f_normal = mat3(transpose(inverse(push_constants.model_view))) * convert(a_normal);
     f_lightmap = a_lightmap;
     f_lightmap_anim = a_lightmap_anim;
     gl_Position = push_constants.transform * vec4(convert(a_position), 1.0);

--- a/shaders/deferred.frag
+++ b/shaders/deferred.frag
@@ -41,12 +41,14 @@ void main() {
   ivec2 texcoord = ivec2(vec2(dims) * a_texcoord);
   vec4 in_color = texelFetch(sampler2DMS(u_diffuse, u_sampler), texcoord, gl_SampleID);
   vec3 in_normal = texelFetch(sampler2DMS(u_normal, u_sampler), texcoord, gl_SampleID).xyz;
-  float in_light = texelFetch(sampler2DMS(u_light, u_sampler), texcoord, gl_SampleID).x;
+  // scale up by 2.0 (see brush.frag)
+  vec4 in_light = 2.0 * texelFetch(sampler2DMS(u_light, u_sampler), texcoord, gl_SampleID);
   float in_depth = texelFetch(sampler2DMS(u_depth, u_sampler), texcoord, gl_SampleID).x;
   vec3 position = reconstruct_position(in_depth);
 
   vec4 out_color = in_color;
-  float light = in_light;
+
+  float light = in_light.x + in_light.y + in_light.z + in_light.w;
   for (uint i = 0; i < u_deferred.light_count && i < MAX_LIGHTS; i++) {
     vec4 dlight = u_deferred.lights[i];
     float dist = abs(distance(dlight_origin(dlight), position));
@@ -58,7 +60,8 @@ void main() {
     }
   }
 
-  light = min(light, 1.0);
+  // allow 200% light saturation
+  light = min(light, 2.0);
 
   color_attachment = vec4(out_color.rgb * light, 1.0);
 }

--- a/shaders/deferred.frag
+++ b/shaders/deferred.frag
@@ -40,7 +40,12 @@ void main() {
   ivec2 dims = textureSize(sampler2DMS(u_diffuse, u_sampler));
   ivec2 texcoord = ivec2(vec2(dims) * a_texcoord);
   vec4 in_color = texelFetch(sampler2DMS(u_diffuse, u_sampler), texcoord, gl_SampleID);
-  vec3 in_normal = texelFetch(sampler2DMS(u_normal, u_sampler), texcoord, gl_SampleID).xyz;
+
+  // scale from [0, 1] to [-1, 1]
+  vec3 in_normal = 2.0
+    * texelFetch(sampler2DMS(u_normal, u_sampler), texcoord, gl_SampleID).xyz
+    - 1.0;
+
   // scale up by 2.0 (see brush.frag)
   vec4 in_light = 2.0 * texelFetch(sampler2DMS(u_light, u_sampler), texcoord, gl_SampleID);
   float in_depth = texelFetch(sampler2DMS(u_depth, u_sampler), texcoord, gl_SampleID).x;
@@ -51,10 +56,11 @@ void main() {
   float light = in_light.x + in_light.y + in_light.z + in_light.w;
   for (uint i = 0; i < u_deferred.light_count && i < MAX_LIGHTS; i++) {
     vec4 dlight = u_deferred.lights[i];
+    vec3 dir = normalize(position - dlight_origin(dlight));
     float dist = abs(distance(dlight_origin(dlight), position));
     float radius = dlight_radius(dlight);
 
-    if (dist < radius) {
+    if (dist < radius && dot(dir, in_normal) < 0.0) {
       // linear attenuation
       light += (radius - dist) / radius;
     }

--- a/src/client/render/ui/hud.rs
+++ b/src/client/render/ui/hud.rs
@@ -535,7 +535,7 @@ impl HudRenderer {
         glyph_cmds.push(GlyphRendererCommand::Glyph {
             glyph_id: '+' as u8,
             position: ScreenPosition::Absolute(Anchor::CENTER),
-            anchor: Anchor::CENTER,
+            anchor: Anchor::TOP_LEFT,
             scale,
         });
     }

--- a/src/client/render/uniform.rs
+++ b/src/client/render/uniform.rs
@@ -35,13 +35,13 @@ impl UniformBool {
 // uniform float array elements are aligned as if they were vec4s
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug)]
-pub struct UniformArrayUint {
-    value: u32,
+pub struct UniformArrayFloat {
+    value: f32,
 }
 
-impl UniformArrayUint {
-    pub fn new(value: u32) -> UniformArrayUint {
-        UniformArrayUint { value }
+impl UniformArrayFloat {
+    pub fn new(value: f32) -> UniformArrayFloat {
+        UniformArrayFloat { value }
     }
 }
 

--- a/src/client/render/world/brush.rs
+++ b/src/client/render/world/brush.rs
@@ -181,7 +181,7 @@ impl BrushPipeline {
 #[derive(Copy, Clone, Debug)]
 pub struct VertexPushConstants {
     pub transform: Matrix4<f32>,
-    pub model: Matrix4<f32>,
+    pub model_view: Matrix4<f32>,
 }
 
 impl Pipeline for BrushPipeline {

--- a/src/client/render/world/mod.rs
+++ b/src/client/render/world/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         entity::particle::Particle,
         render::{
             pipeline::Pipeline,
-            uniform::{DynamicUniformBufferBlock, UniformArrayUint, UniformBool},
+            uniform::{DynamicUniformBufferBlock, UniformArrayFloat, UniformBool},
             world::{
                 alias::{AliasPipeline, AliasRenderer},
                 brush::{BrushPipeline, BrushRenderer, BrushRendererBuilder},
@@ -261,7 +261,7 @@ impl Camera {
 // TODO: derive Debug once const generics are stable
 pub struct FrameUniforms {
     // TODO: pack frame values into a [Vector4<f32>; 16],
-    lightmap_anim_frames: [UniformArrayUint; 64],
+    lightmap_anim_frames: [UniformArrayFloat; 64],
     camera_pos: Vector4<f32>,
     time: f32,
 
@@ -363,7 +363,7 @@ impl WorldRenderer {
         camera: &Camera,
         time: Duration,
         entities: I,
-        lightstyle_values: &[u32],
+        lightstyle_values: &[f32],
         cvars: &CvarRegistry,
     ) where
         I: Iterator<Item = &'a ClientEntity>,
@@ -374,9 +374,9 @@ impl WorldRenderer {
             .write_buffer(state.frame_uniform_buffer(), 0, unsafe {
                 any_as_bytes(&FrameUniforms {
                     lightmap_anim_frames: {
-                        let mut frames = [UniformArrayUint::new(0); 64];
+                        let mut frames = [UniformArrayFloat::new(0.0); 64];
                         for i in 0..64 {
-                            frames[i] = UniformArrayUint::new(lightstyle_values[i]);
+                            frames[i] = UniformArrayFloat::new(lightstyle_values[i]);
                         }
                         frames
                     },
@@ -424,7 +424,7 @@ impl WorldRenderer {
         time: Duration,
         entities: E,
         particles: P,
-        lightstyle_values: &[u32],
+        lightstyle_values: &[f32],
         cvars: &CvarRegistry,
     ) where
         E: Iterator<Item = &'a ClientEntity> + Clone,

--- a/src/client/render/world/mod.rs
+++ b/src/client/render/world/mod.rs
@@ -464,7 +464,7 @@ impl WorldRenderer {
             &state.world_bind_groups()[BindGroupLayoutId::PerEntity as usize],
             &[self.world_uniform_block.offset()],
         );
-        self.worldmodel_renderer.record_draw(state, pass, &bump, camera);
+        self.worldmodel_renderer.record_draw(state, pass, &bump, time, camera);
 
         // draw entities
         info!("Drawing entities");
@@ -487,7 +487,7 @@ impl WorldRenderer {
                         Retain,
                         Retain,
                     );
-                    bmodel.record_draw(state, pass, &bump, camera);
+                    bmodel.record_draw(state, pass, &bump, time, camera);
                 }
                 EntityRenderer::Alias(ref alias) => {
                     pass.set_pipeline(state.alias_pipeline().pipeline());

--- a/src/client/render/world/mod.rs
+++ b/src/client/render/world/mod.rs
@@ -453,7 +453,7 @@ impl WorldRenderer {
             pass,
             Some(bump.alloc(brush::VertexPushConstants {
                 transform: camera.view_projection(),
-                model: Matrix4::identity(),
+                model_view: camera.view(),
             })),
             None,
             None,
@@ -481,7 +481,7 @@ impl WorldRenderer {
                         pass,
                         Some(bump.alloc(brush::VertexPushConstants {
                             transform: self.calculate_mvp_transform(camera, ent),
-                            model: self.calculate_model_transform(camera, ent),
+                            model_view: self.calculate_mv_transform(camera, ent),
                         })),
                         None,
                         None,
@@ -517,6 +517,12 @@ impl WorldRenderer {
         let model_transform = self.calculate_model_transform(camera, entity);
 
         camera.view_projection() * model_transform
+    }
+
+    fn calculate_mv_transform(&self, camera: &Camera, entity: &ClientEntity) -> Matrix4<f32> {
+        let model_transform = self.calculate_model_transform(camera, entity);
+
+        camera.view() * model_transform
     }
 
     fn calculate_model_transform(&self, camera: &Camera, entity: &ClientEntity) -> Matrix4<f32> {

--- a/src/client/render/world/particle.rs
+++ b/src/client/render/world/particle.rs
@@ -5,7 +5,7 @@ use crate::{
         entity::particle::Particle,
         render::{
             create_texture,
-            pipeline::Pipeline,
+            pipeline::{Pipeline, PushConstantUpdate},
             world::{Camera, WorldPipelineBase},
             Palette, TextureData,
         },
@@ -191,6 +191,8 @@ impl ParticlePipeline {
     ) where
         P: Iterator<Item = &'b Particle>,
     {
+        use PushConstantUpdate::*;
+
         pass.set_pipeline(self.pipeline());
         pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         pass.set_bind_group(0, &self.bind_group, &[]);
@@ -210,11 +212,11 @@ impl ParticlePipeline {
                 Matrix4::from_translation([-q_origin.y, q_origin.z, -q_origin.x].into());
             Self::set_push_constants(
                 pass,
-                Some(bump.alloc(VertexPushConstants {
+                Update(bump.alloc(VertexPushConstants {
                     transform: camera.view_projection() * translation * rotation,
                 })),
-                None,
-                Some(bump.alloc(FragmentPushConstants {
+                Retain,
+                Update(bump.alloc(FragmentPushConstants {
                     color: particle.color() as u32,
                 })),
             );

--- a/src/common/bsp/mod.rs
+++ b/src/common/bsp/mod.rs
@@ -226,6 +226,11 @@ impl BspTexture {
     pub fn mipmap(&self, mipmap: BspTextureMipmap) -> &[u8] {
         &self.mipmaps[mipmap as usize]
     }
+
+    /// Returns this texture's animation data, if any.
+    pub fn animation(&self) -> Option<&BspTextureAnimation> {
+        self.animation.as_ref()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Improves a number of rendering issues, including:

- Dynamic lights now only show on surfaces "facing" the light source (i.e., surfaces whose normals have a negative dot product with the direction vector from the light to the surface). Dynamic lights still do not have shadows, however.
- Lightmap calculations have been simplified to remove the 8.8 fixed-point math. Surfaces with multiple lightmaps have each lightmap written to a separate channel of the light target.
- `brush::TextureKind` is now uploaded using push constants rather than a dynamic uniform buffer.
- Animated brush textures now work. Alternate animations are still forthcoming.
- The crosshair has been offset slightly to more accurately reflect the direction of projectiles. This is not a totally solvable problem due to limited precision with which Quake sends angles over the network.