### PR TITLE
Sound update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ chrono = "0.4.0"
 env_logger = "0.5.3"
 failure = "0.1.8"
 futures = "0.3.5"
-hound = "3.4.0"
 lazy_static = "1.0.0"
 log = "0.4.1"
 nom = "5.1"
@@ -23,7 +22,8 @@ num-derive = "0.1.42"
 png = "0.16"
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "0.2.6"
-rodio = "0.11.0"
+# rodio = "0.12"
+rodio = { git = "https://github.com/RustAudio/rodio", rev = "82b4952" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shaderc = "0.6.2"

--- a/src/bin/quake-client/main.rs
+++ b/src/bin/quake-client/main.rs
@@ -73,8 +73,6 @@ struct ClientProgram {
     gfx_state: RefCell<GraphicsState>,
     ui_renderer: Rc<UiRenderer>,
 
-    audio_device: Rc<rodio::Device>,
-
     game: Game,
     input: Rc<RefCell<Input>>,
 }
@@ -82,7 +80,6 @@ struct ClientProgram {
 impl ClientProgram {
     pub async fn new(
         window: Window,
-        audio_device: Rc<rodio::Device>,
         trace: bool,
     ) -> ClientProgram {
         let mut vfs = Vfs::new();
@@ -215,7 +212,6 @@ impl ClientProgram {
             cmds.clone(),
             console.clone(),
             input.clone(),
-            audio_device.clone(),
             &gfx_state,
             &menu.borrow(),
         );
@@ -234,7 +230,6 @@ impl ClientProgram {
             swap_chain,
             gfx_state: RefCell::new(gfx_state),
             ui_renderer,
-            audio_device,
             game,
             input,
         }
@@ -362,8 +357,6 @@ fn main() {
     env_logger::init();
     let opt = Opt::from_args();
 
-    let audio_device = Rc::new(rodio::default_output_device().unwrap());
-
     let event_loop = EventLoop::new();
     let window = {
         #[cfg(target_os = "windows")]
@@ -389,7 +382,7 @@ fn main() {
     };
 
     let client_program =
-        futures::executor::block_on(ClientProgram::new(window, audio_device, opt.trace));
+        futures::executor::block_on(ClientProgram::new(window, opt.trace));
 
     // TODO: make dump_demo part of top-level binary and allow choosing file name
     if let Some(ref demo) = opt.dump_demo {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -44,7 +44,7 @@ use crate::{
         demo::{DemoServer, DemoServerError},
         entity::{ClientEntity, MAX_STATIC_ENTITIES},
         input::{game::GameInput, Input},
-        sound::{AudioSource, Channel, Listener, StaticSound},
+        sound::StaticSound,
         state::{ClientState, PlayerInfo},
         trace::{TraceEntity, TraceFrame},
         view::{IdleVars, KickVars, MouseVars, RollVars},
@@ -517,7 +517,7 @@ impl Connection {
                     entity_id,
                     channel,
                     sound_id,
-                    position: _,
+                    position,
                 } => {
                     trace!(
                         "starting sound with id {} on entity {} channel {}",
@@ -540,11 +540,11 @@ impl Connection {
                     self.state.mixer.start_sound(
                         self.state.sounds[sound_id as usize].clone(),
                         self.state.msg_times[0],
-                        entity_id as usize,
+                        Some(entity_id as usize),
                         channel,
                         volume as f32 / 255.0,
                         attenuation,
-                        &self.state.entities,
+                        position,
                         &self.state.listener,
                     );
                 }

--- a/src/client/sound/mod.rs
+++ b/src/client/sound/mod.rs
@@ -245,7 +245,8 @@ impl Channel {
 
 pub struct EntityChannel {
     start_time: Duration,
-    ent_id: usize,
+    // if None, sound is associated with a temp entity
+    ent_id: Option<usize>,
     ent_channel: i8,
     channel: Channel,
 }
@@ -255,7 +256,7 @@ impl EntityChannel {
         &self.channel
     }
 
-    pub fn entity_id(&self) -> usize {
+    pub fn entity_id(&self) -> Option<usize> {
         self.ent_id
     }
 }
@@ -280,7 +281,7 @@ impl EntityMixer {
         }
     }
 
-    fn find_free_channel(&self, ent_id: usize, ent_channel: i8) -> usize {
+    fn find_free_channel(&self, ent_id: Option<usize>, ent_channel: i8) -> usize {
         let mut oldest = 0;
 
         for (i, channel) in self.channels.iter().enumerate() {
@@ -324,11 +325,11 @@ impl EntityMixer {
         &mut self,
         src: AudioSource,
         time: Duration,
-        ent_id: usize,
+        ent_id: Option<usize>,
         ent_channel: i8,
         volume: f32,
         attenuation: f32,
-        ents: &[ClientEntity],
+        origin: Vector3<f32>,
         listener: &Listener,
     ) {
         let chan_id = self.find_free_channel(ent_id, ent_channel);
@@ -336,7 +337,7 @@ impl EntityMixer {
 
         new_channel.play(
             src.clone(),
-            ents[ent_id].origin,
+            origin,
             listener,
             volume,
             attenuation,

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -8,9 +8,9 @@ use crate::{
         },
         input::game::{Action, GameInput},
         render::Camera,
-        sound::{AudioSource, Listener, StaticSound},
+        sound::{AudioSource, EntityMixer, Listener, StaticSound},
         view::{IdleVars, KickVars, MouseVars, RollVars, View},
-        ClientError, ColorShiftCode, IntermissionKind, Mixer, MoveVars, MAX_STATS,
+        ClientError, ColorShiftCode, IntermissionKind, MoveVars, MAX_STATS,
     },
     common::{
         bsp, engine,
@@ -93,7 +93,7 @@ pub struct ClientState {
     pub start_time: Duration,
     pub completion_time: Option<Duration>,
 
-    pub mixer: Mixer,
+    pub mixer: EntityMixer,
     pub listener: Listener,
 }
 
@@ -148,7 +148,7 @@ impl ClientState {
             intermission: None,
             start_time: Duration::zero(),
             completion_time: None,
-            mixer: Mixer::new(stream),
+            mixer: EntityMixer::new(stream),
             listener: Listener::new(),
         }
     }
@@ -968,12 +968,11 @@ impl ClientState {
         self.update_listener();
 
         // update entity sounds
-        for opt_chan in self.mixer.channels.iter() {
-            if let Some(ref chan) = opt_chan {
-                if chan.channel.in_use() {
-                    chan.channel
-                        .update(self.entities[chan.ent_id].origin, &self.listener);
-                }
+        for e_channel in self.mixer.iter_entity_channels() {
+            if e_channel.channel().in_use() {
+                e_channel
+                    .channel()
+                    .update(self.entities[e_channel.entity_id()].origin, &self.listener);
             }
         }
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -28,6 +28,7 @@ use cgmath::{Angle as _, Deg, InnerSpace as _, Matrix4, Vector3, Zero as _};
 use chrono::Duration;
 use net::{ClientCmd, ClientStat, EntityState, EntityUpdate, PlayerColor};
 use rand::distributions::{Distribution as _, Uniform};
+use rodio::OutputStreamHandle;
 
 pub struct PlayerInfo {
     pub name: String,
@@ -98,7 +99,7 @@ pub struct ClientState {
 
 impl ClientState {
     // TODO: add parameter for number of player slots and reserve them in entity list
-    pub fn new(audio_device: Rc<rodio::Device>) -> ClientState {
+    pub fn new(stream: OutputStreamHandle) -> ClientState {
         ClientState {
             models: vec![Model::none()],
             model_names: HashMap::new(),
@@ -147,14 +148,14 @@ impl ClientState {
             intermission: None,
             start_time: Duration::zero(),
             completion_time: None,
-            mixer: Mixer::new(audio_device.clone()),
+            mixer: Mixer::new(stream),
             listener: Listener::new(),
         }
     }
 
     pub fn from_server_info(
         vfs: &Vfs,
-        audio_device: Rc<rodio::Device>,
+        stream: OutputStreamHandle,
         max_clients: u8,
         model_precache: Vec<String>,
         sound_precache: Vec<String>,
@@ -197,7 +198,7 @@ impl ClientState {
             model_names,
             sounds,
             max_players: max_clients as usize,
-            ..ClientState::new(audio_device)
+            ..ClientState::new(stream)
         })
     }
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -27,8 +27,22 @@ use arrayvec::ArrayVec;
 use cgmath::{Angle as _, Deg, InnerSpace as _, Matrix4, Vector3, Zero as _};
 use chrono::Duration;
 use net::{ClientCmd, ClientStat, EntityState, EntityUpdate, PlayerColor};
-use rand::distributions::{Distribution as _, Uniform};
+use rand::{
+    distributions::{Distribution as _, Uniform},
+    rngs::SmallRng,
+    SeedableRng,
+};
 use rodio::OutputStreamHandle;
+
+const CACHED_SOUND_NAMES: &[&'static str] = &[
+    "hknight/hit.wav",
+    "weapons/r_exp3.wav",
+    "weapons/ric1.wav",
+    "weapons/ric2.wav",
+    "weapons/ric3.wav",
+    "weapons/tink1.wav",
+    "wizard/hit.wav",
+];
 
 pub struct PlayerInfo {
     pub name: String,
@@ -39,6 +53,9 @@ pub struct PlayerInfo {
 
 // client information regarding the current level
 pub struct ClientState {
+    // local rng
+    rng: SmallRng,
+
     // model precache
     pub models: Vec<Model>,
     // name-to-id map
@@ -46,6 +63,9 @@ pub struct ClientState {
 
     // audio source precache
     pub sounds: Vec<AudioSource>,
+
+    // sounds that are always needed even if not in precache
+    cached_sounds: HashMap<String, AudioSource>,
 
     // ambient sounds (infinite looping, static position)
     pub static_sounds: Vec<StaticSound>,
@@ -101,9 +121,11 @@ impl ClientState {
     // TODO: add parameter for number of player slots and reserve them in entity list
     pub fn new(stream: OutputStreamHandle) -> ClientState {
         ClientState {
+            rng: SmallRng::from_entropy(),
             models: vec![Model::none()],
             model_names: HashMap::new(),
             sounds: Vec::new(),
+            cached_sounds: HashMap::new(),
             static_sounds: Vec::new(),
             entities: Vec::new(),
             static_entities: Vec::new(),
@@ -193,10 +215,16 @@ impl ClientState {
             // TODO: send keepalive message?
         }
 
+        let mut cached_sounds = HashMap::new();
+        for name in CACHED_SOUND_NAMES {
+            cached_sounds.insert(name.to_string(), AudioSource::load(vfs, name)?);
+        }
+
         Ok(ClientState {
             models,
             model_names,
             sounds,
+            cached_sounds,
             max_players: max_clients as usize,
             ..ClientState::new(stream)
         })
@@ -359,9 +387,6 @@ impl ClientState {
                 self.particles.create_entity_field(self.time, ent);
             }
 
-            // TODO: cache a SmallRng in Client
-            let mut rng = rand::thread_rng();
-
             // TODO: factor out EntityEffects->LightDesc mapping
             if ent.effects.contains(EntityEffects::MUZZLE_FLASH) {
                 // TODO: angle and move origin to muzzle
@@ -369,7 +394,7 @@ impl ClientState {
                     self.time,
                     LightDesc {
                         origin: ent.origin + Vector3::new(0.0, 0.0, 16.0),
-                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut rng),
+                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut self.rng),
                         decay_rate: 0.0,
                         min_radius: Some(32.0),
                         ttl: Duration::milliseconds(100),
@@ -383,7 +408,7 @@ impl ClientState {
                     self.time,
                     LightDesc {
                         origin: ent.origin,
-                        init_radius: BRIGHTLIGHT_DISTRIBUTION.sample(&mut rng),
+                        init_radius: BRIGHTLIGHT_DISTRIBUTION.sample(&mut self.rng),
                         decay_rate: 0.0,
                         min_radius: None,
                         ttl: Duration::milliseconds(1),
@@ -397,7 +422,7 @@ impl ClientState {
                     self.time,
                     LightDesc {
                         origin: ent.origin,
-                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut rng),
+                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut self.rng),
                         decay_rate: 0.0,
                         min_radius: None,
                         ttl: Duration::milliseconds(1),
@@ -451,15 +476,13 @@ impl ClientState {
 
         // apply effects to static entities as well
         for ent in self.static_entities.iter_mut() {
-            let mut rng = rand::thread_rng();
-
             if ent.effects.contains(EntityEffects::BRIGHT_LIGHT) {
                 debug!("spawn bright light on static entity");
                 ent.light_id = Some(self.lights.insert(
                     self.time,
                     LightDesc {
                         origin: ent.origin,
-                        init_radius: BRIGHTLIGHT_DISTRIBUTION.sample(&mut rng),
+                        init_radius: BRIGHTLIGHT_DISTRIBUTION.sample(&mut self.rng),
                         decay_rate: 0.0,
                         min_radius: None,
                         ttl: Duration::milliseconds(1),
@@ -474,7 +497,7 @@ impl ClientState {
                     self.time,
                     LightDesc {
                         origin: ent.origin,
-                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut rng),
+                        init_radius: MFLASH_DIMLIGHT_DISTRIBUTION.sample(&mut self.rng),
                         decay_rate: 0.0,
                         min_radius: None,
                         ttl: Duration::milliseconds(1),
@@ -520,7 +543,7 @@ impl ClientState {
                     ent.angles = Vector3::new(
                         pitch,
                         yaw,
-                        Deg(ANGLE_DISTRIBUTION.sample(&mut rand::thread_rng())),
+                        Deg(ANGLE_DISTRIBUTION.sample(&mut self.rng)),
                     );
 
                     if self.temp_entities.len() < MAX_TEMP_ENTITIES {
@@ -794,29 +817,43 @@ impl ClientState {
     }
 
     pub fn spawn_temp_entity(&mut self, temp_entity: &TempEntity) {
+        lazy_static! {
+            static ref ZERO_ONE_DISTRIBUTION: Uniform<f32> = Uniform::new(0.0, 1.0);
+        }
+
+        let mut spike_sound = || match ZERO_ONE_DISTRIBUTION.sample(&mut self.rng) {
+            x if x < 0.2 => "weapons/tink1.wav",
+            x if x < 0.4667 => "weapons/ric1.wav",
+            x if x < 0.7333 => "weapons/ric2.wav",
+            _ => "weapons/ric3.wav",
+        };
+
         match temp_entity {
             TempEntity::Point { kind, origin } => {
                 use PointEntityKind::*;
                 match kind {
                     // projectile impacts
                     WizSpike | KnightSpike | Spike | SuperSpike | Gunshot => {
-                        let (color, count) = match kind {
+                        let (color, count, sound) = match kind {
                             // TODO: start wizard/hit.wav
-                            WizSpike => (20, 30),
+                            WizSpike => {
+                                (20, 30, Some("wizard/hit.wav"))
+                            }
 
-                            // TODO: start hknight/hit.wav
-                            KnightSpike => (226, 20),
+                            KnightSpike => {
+                                (226, 20, Some("hknight/hit.wav"))
+                            }
 
                             // TODO: for Spike and SuperSpike, start one of:
                             // - 26.67%: weapons/tink1.wav
                             // - 20.0%: weapons/ric1.wav
                             // - 20.0%: weapons/ric2.wav
                             // - 20.0%: weapons/ric3.wav
-                            Spike => (0, 10),
-                            SuperSpike => (0, 20),
+                            Spike => (0, 10, Some(spike_sound())),
+                            SuperSpike => (0, 20, Some(spike_sound())),
 
-                            // no sound
-                            Gunshot => (0, 20),
+                            // no impact sound
+                            Gunshot => (0, 20, None),
                             _ => unreachable!(),
                         };
 
@@ -827,6 +864,22 @@ impl ClientState {
                             color,
                             count,
                         );
+
+                        if let Some(snd) = sound {
+                            self.mixer.start_sound(
+                                self.cached_sounds
+                                    .get(snd)
+                                    .unwrap()
+                                    .clone(),
+                                self.time,
+                                None,
+                                0,
+                                1.0,
+                                1.0,
+                                *origin,
+                                &self.listener,
+                            );
+                        }
                     }
 
                     Explosion => {
@@ -842,7 +895,20 @@ impl ClientState {
                             },
                             None,
                         );
-                        // TODO: start weapons/r_exp3
+
+                        self.mixer.start_sound(
+                            self.cached_sounds
+                                .get("weapons/r_exp3.wav")
+                                .unwrap()
+                                .clone(),
+                            self.time,
+                            None,
+                            0,
+                            1.0,
+                            1.0,
+                            *origin,
+                            &self.listener,
+                        );
                     }
 
                     ColorExplosion {
@@ -865,12 +931,38 @@ impl ClientState {
                             },
                             None,
                         );
-                        // TODO: start weapons/r_exp3
+
+                        self.mixer.start_sound(
+                            self.cached_sounds
+                                .get("weapons/r_exp3.wav")
+                                .unwrap()
+                                .clone(),
+                            self.time,
+                            None,
+                            0,
+                            1.0,
+                            1.0,
+                            *origin,
+                            &self.listener,
+                        );
                     }
 
                     TarExplosion => {
                         self.particles.create_spawn_explosion(self.time, *origin);
-                        // TODO: start weapons/r_exp3 (same sound as rocket explosion)
+
+                        self.mixer.start_sound(
+                            self.cached_sounds
+                                .get("weapons/r_exp3.wav")
+                                .unwrap()
+                                .clone(),
+                            self.time,
+                            None,
+                            0,
+                            1.0,
+                            1.0,
+                            *origin,
+                            &self.listener,
+                        );
                     }
 
                     LavaSplash => self.particles.create_lava_splash(self.time, *origin),
@@ -969,10 +1061,12 @@ impl ClientState {
 
         // update entity sounds
         for e_channel in self.mixer.iter_entity_channels() {
-            if e_channel.channel().in_use() {
-                e_channel
-                    .channel()
-                    .update(self.entities[e_channel.entity_id()].origin, &self.listener);
+            if let Some(ent_id) = e_channel.entity_id() {
+                if e_channel.channel().in_use() {
+                    e_channel
+                        .channel()
+                        .update(self.entities[ent_id].origin, &self.listener);
+                }
             }
         }
 


### PR DESCRIPTION
Improved some sound issues, including:
- Updated `rodio` dependency to latest master, allowing `hound` to be dropped as a direct dependency
- Factored `Mixer` (now `EntityMixer`) out of `client` root into `client::sound`
- Enabled temp entity sound effects (rocket/grenade explosions, nailgun ricochets, etc.)