### PR TITLE
More fixin'

### DIFF
--- a/src/bin/quake-client/main.rs
+++ b/src/bin/quake-client/main.rs
@@ -25,10 +25,12 @@ mod trace;
 
 use std::{
     cell::{Ref, RefCell, RefMut},
+    fs::File,
     io::{Cursor, Read, Write},
     net::SocketAddr,
-    path::Path,
-    rc::Rc, fs::File,
+    path::{Path, PathBuf},
+    process::exit,
+    rc::Rc,
 };
 
 use game::Game;
@@ -78,28 +80,49 @@ struct ClientProgram {
 }
 
 impl ClientProgram {
-    pub async fn new(
-        window: Window,
-        trace: bool,
-    ) -> ClientProgram {
+    pub async fn new(window: Window, base_dir: Option<PathBuf>, trace: bool) -> ClientProgram {
         let mut vfs = Vfs::new();
 
-        // add basedir first
-        vfs.add_directory(common::DEFAULT_BASEDIR).unwrap();
+        let mut game_dir = base_dir.unwrap_or_else(|| common::default_base_dir());
+        game_dir.push("id1");
 
-        // then add PAK archives
+        if !game_dir.is_dir() {
+            log::error!(concat!(
+                "`id1/` directory does not exist! Use the `--base-dir` option with the name of the",
+                " directory which contains `id1/`."
+            ));
+
+            exit(1);
+        }
+
+        vfs.add_directory(&game_dir).unwrap();
+
+        // ...then add PAK archives.
+        let mut num_paks = 0;
+        let mut pak_path = game_dir;
         for vfs_id in 0..common::MAX_PAKFILES {
-            // TODO: check `-basedir` command line argument
-            let basedir = common::DEFAULT_BASEDIR;
-            let path_string = format!("{}/pak{}.pak", basedir, vfs_id);
-            let path = Path::new(&path_string);
+            // Add the file name.
+            pak_path.push(format!("pak{}.pak", vfs_id));
 
-            // keep adding PAKs until we don't find one or we hit MAX_PAKFILES
-            if !path.exists() {
-                break;
+            // Keep adding PAKs until we don't find one or we hit MAX_PAKFILES.
+            if !pak_path.exists() {
+                // If the lowercase path doesn't exist, try again with uppercase.
+                pak_path.pop();
+                pak_path.push(format!("PAK{}.PAK", vfs_id));
+                if !pak_path.exists() {
+                    break;
+                }
             }
 
-            vfs.add_pakfile(path).unwrap();
+            vfs.add_pakfile(&pak_path).unwrap();
+            num_paks += 1;
+
+            // Remove the file name, leaving the game directory.
+            pak_path.pop();
+        }
+
+        if num_paks == 0 {
+            log::warn!("No PAK files found.");
         }
 
         let cvars = Rc::new(RefCell::new(CvarRegistry::new()));
@@ -358,6 +381,9 @@ struct Opt {
 
     #[structopt(long)]
     demo: Option<String>,
+
+    #[structopt(long)]
+    base_dir: Option<PathBuf>,
 }
 
 fn main() {
@@ -389,7 +415,7 @@ fn main() {
     };
 
     let client_program =
-        futures::executor::block_on(ClientProgram::new(window, opt.trace));
+        futures::executor::block_on(ClientProgram::new(window, opt.base_dir, opt.trace));
 
     // TODO: make dump_demo part of top-level binary and allow choosing file name
     if let Some(ref demo) = opt.dump_demo {

--- a/src/bin/quake-client/main.rs
+++ b/src/bin/quake-client/main.rs
@@ -309,12 +309,19 @@ impl Program for ClientProgram {
 
         match self.input.borrow().focus() {
             InputFocus::Game => {
-                self.window.set_cursor_grab(true).unwrap();
+                if let Err(e) = self.window.set_cursor_grab(true) {
+                    // This can happen if the window is running in another
+                    // workspace. It shouldn't be considered an error.
+                    log::debug!("Couldn't grab cursor: {}", e);
+                }
+
                 self.window.set_cursor_visible(false);
             }
 
             _ => {
-                self.window.set_cursor_grab(false).unwrap();
+                if let Err(e) = self.window.set_cursor_grab(false) {
+                    log::debug!("Couldn't release cursor: {}", e);
+                };
                 self.window.set_cursor_visible(true);
             }
         }

--- a/src/bin/quake-client/main.rs
+++ b/src/bin/quake-client/main.rs
@@ -125,11 +125,13 @@ impl ClientProgram {
             log::warn!("No PAK files found.");
         }
 
-        let cvars = Rc::new(RefCell::new(CvarRegistry::new()));
+        let con_names = Rc::new(RefCell::new(Vec::new()));
+
+        let cvars = Rc::new(RefCell::new(CvarRegistry::new(con_names.clone())));
         client::register_cvars(&cvars.borrow()).unwrap();
         render::register_cvars(&cvars.borrow());
 
-        let cmds = Rc::new(RefCell::new(CmdRegistry::new()));
+        let cmds = Rc::new(RefCell::new(CmdRegistry::new(con_names)));
         // TODO: register commands as other subsystems come online
 
         let console = Rc::new(RefCell::new(Console::new(cmds.clone(), cvars.clone())));
@@ -224,7 +226,7 @@ impl ClientProgram {
                     _ => format!("exec (filename): execute a script file"),
                 }
             }),
-        );
+        ).unwrap();
 
         // this will also execute config.cfg and autoexec.cfg (assuming an unmodified quake.rc)
         console.borrow().stuff_text("exec quake.rc\n");

--- a/src/client/input/game.rs
+++ b/src/client/input/game.rs
@@ -624,7 +624,8 @@ impl GameInput {
                         action_states.borrow_mut()[action as usize] = state_bool;
                         String::new()
                     }),
-                );
+                )
+                .unwrap();
             }
         }
 
@@ -647,18 +648,16 @@ impl GameInput {
 
                     // bind (key) [command]
                     2 => match BindInput::from_str(args[0]) {
-                        Ok(input) => {
-                            match BindTarget::from_str(args[1]) {
-                                Ok(target) => {
-                                    bindings.borrow_mut().insert(input, target);
-                                    debug!("Bound {:?} to {:?}", input, args[1]);
-                                    String::new()
-                                }
-                                Err(_) => {
-                                    format!("\"{}\" isn't a valid bind target", args[1])
-                                }
+                        Ok(input) => match BindTarget::from_str(args[1]) {
+                            Ok(target) => {
+                                bindings.borrow_mut().insert(input, target);
+                                debug!("Bound {:?} to {:?}", input, args[1]);
+                                String::new()
                             }
-                        }
+                            Err(_) => {
+                                format!("\"{}\" isn't a valid bind target", args[1])
+                            }
+                        },
 
                         Err(_) => format!("\"{}\" isn't a valid key", args[0]),
                     },
@@ -666,7 +665,8 @@ impl GameInput {
                     _ => "bind [key] (command): attach a command to a key".to_owned(),
                 }
             }),
-        );
+        )
+        .unwrap();
 
         // "unbindall"
         let bindings = self.bindings.clone();
@@ -679,7 +679,8 @@ impl GameInput {
                 }
                 _ => "unbindall: delete all keybindings".to_owned(),
             }),
-        );
+        )
+        .unwrap();
 
         // "impulse"
         let impulse = self.impulse.clone();
@@ -689,14 +690,18 @@ impl GameInput {
                 println!("args: {}", args.len());
                 match args.len() {
                     1 => match u8::from_str(args[0]) {
-                        Ok(i) => {impulse.set(i); String::new()},
+                        Ok(i) => {
+                            impulse.set(i);
+                            String::new()
+                        }
                         Err(_) => "Impulse must be a number between 0 and 255".to_owned(),
                     },
 
                     _ => "usage: impulse [number]".to_owned(),
                 }
             }),
-        );
+        )
+        .unwrap();
     }
 
     // must be called every frame!

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -499,7 +499,8 @@ impl Connection {
                             });
                             String::new()
                         }),
-                    );
+                    )
+                    .unwrap();
                 }
 
                 ServerCmd::SetAngle { angles } => self.state.set_view_angles(angles),
@@ -838,50 +839,65 @@ impl Client {
         };
 
         // set up overlay/ui toggles
-        cmds.borrow_mut().insert_or_replace(
-            "toggleconsole",
-            cmd_toggleconsole(conn.clone(), input.clone()),
-        );
         cmds.borrow_mut()
-            .insert_or_replace("togglemenu", cmd_togglemenu(conn.clone(), input.clone()));
+            .insert_or_replace(
+                "toggleconsole",
+                cmd_toggleconsole(conn.clone(), input.clone()),
+            )
+            .unwrap();
+        cmds.borrow_mut()
+            .insert_or_replace("togglemenu", cmd_togglemenu(conn.clone(), input.clone()))
+            .unwrap();
 
         // set up connection console commands
-        cmds.borrow_mut().insert_or_replace(
-            "connect",
-            cmd_connect(conn.clone(), input.clone(), handle.clone()),
-        );
         cmds.borrow_mut()
-            .insert_or_replace("reconnect", cmd_reconnect(conn.clone(), input.clone()));
+            .insert_or_replace(
+                "connect",
+                cmd_connect(conn.clone(), input.clone(), handle.clone()),
+            )
+            .unwrap();
         cmds.borrow_mut()
-            .insert_or_replace("disconnect", cmd_disconnect(conn.clone(), input.clone()));
+            .insert_or_replace("reconnect", cmd_reconnect(conn.clone(), input.clone()))
+            .unwrap();
+        cmds.borrow_mut()
+            .insert_or_replace("disconnect", cmd_disconnect(conn.clone(), input.clone()))
+            .unwrap();
 
         // set up demo playback
-        cmds.borrow_mut().insert_or_replace(
-            "playdemo",
-            cmd_playdemo(conn.clone(), vfs.clone(), input.clone(), handle.clone()),
-        );
+        cmds.borrow_mut()
+            .insert_or_replace(
+                "playdemo",
+                cmd_playdemo(conn.clone(), vfs.clone(), input.clone(), handle.clone()),
+            )
+            .unwrap();
 
         let demo_queue = Rc::new(RefCell::new(VecDeque::new()));
-        cmds.borrow_mut().insert_or_replace(
-            "startdemos",
-            cmd_startdemos(
-                conn.clone(),
-                vfs.clone(),
-                input.clone(),
-                handle.clone(),
-                demo_queue.clone(),
-            ),
-        );
+        cmds.borrow_mut()
+            .insert_or_replace(
+                "startdemos",
+                cmd_startdemos(
+                    conn.clone(),
+                    vfs.clone(),
+                    input.clone(),
+                    handle.clone(),
+                    demo_queue.clone(),
+                ),
+            )
+            .unwrap();
 
         let music_player = Rc::new(RefCell::new(MusicPlayer::new(vfs.clone(), handle.clone())));
         cmds.borrow_mut()
-            .insert_or_replace("music", cmd_music(music_player.clone()));
+            .insert_or_replace("music", cmd_music(music_player.clone()))
+            .unwrap();
         cmds.borrow_mut()
-            .insert_or_replace("music_stop", cmd_music_stop(music_player.clone()));
+            .insert_or_replace("music_stop", cmd_music_stop(music_player.clone()))
+            .unwrap();
         cmds.borrow_mut()
-            .insert_or_replace("music_pause", cmd_music_pause(music_player.clone()));
+            .insert_or_replace("music_pause", cmd_music_pause(music_player.clone()))
+            .unwrap();
         cmds.borrow_mut()
-            .insert_or_replace("music_resume", cmd_music_resume(music_player.clone()));
+            .insert_or_replace("music_resume", cmd_music_resume(music_player.clone()))
+            .unwrap();
 
         Client {
             vfs,

--- a/src/client/render/world/mod.rs
+++ b/src/client/render/world/mod.rs
@@ -527,15 +527,14 @@ impl WorldRenderer {
         }
 
         let viewmodel_orig = camera.origin();
-        let mut viewmodel_angles = camera.angles();
-        viewmodel_angles.pitch = -viewmodel_angles.roll;
-        viewmodel_angles.yaw = -viewmodel_angles.yaw;
-        viewmodel_angles.roll = -viewmodel_angles.pitch;
+        let cam_angles = camera.angles();
         let viewmodel_mat = Matrix4::from_translation(Vector3::new(
             -viewmodel_orig.y,
             viewmodel_orig.z,
             -viewmodel_orig.x,
-        )) * viewmodel_angles.mat4_wgpu();
+        )) * Matrix4::from_angle_y(cam_angles.yaw)
+            * Matrix4::from_angle_x(-cam_angles.pitch)
+            * Matrix4::from_angle_z(cam_angles.roll);
         match self.entity_renderers[viewmodel_id] {
             EntityRenderer::Alias(ref alias) => {
                 pass.set_pipeline(state.alias_pipeline().pipeline());

--- a/src/common/console/mod.rs
+++ b/src/common/console/mod.rs
@@ -21,6 +21,7 @@
 use std::{
     cell::{Ref, RefCell},
     collections::{HashMap, VecDeque},
+    fmt::Write,
     iter::FromIterator,
     rc::Rc,
 };
@@ -36,11 +37,9 @@ pub enum ConsoleError {
     CmdError(String),
     #[error("Could not parse cvar as a number: {name} = \"{value}\"")]
     CvarParseFailed { name: String, value: String },
-    #[error(
-        "Command already registered: {0} (to replace existing definition, use `insert_or_replace`)"
-    )]
+    #[error("A command named \"{0}\" already exists")]
     DuplicateCommand(String),
-    #[error("Cvar already registered: {0}")]
+    #[error("A cvar named \"{0}\" already exists")]
     DuplicateCvar(String),
     #[error("No such command: {0}")]
     NoSuchCommand(String),
@@ -50,15 +49,31 @@ pub enum ConsoleError {
 
 type Cmd = Box<dyn Fn(&[&str]) -> String>;
 
+fn insert_name<S>(names: &mut Vec<String>, name: S) -> Result<usize, usize>
+where
+    S: AsRef<str>,
+{
+    let name = name.as_ref();
+    match names.binary_search_by(|item| item.as_str().cmp(name)) {
+        Ok(i) => Err(i),
+        Err(i) => {
+            names.insert(i, name.to_owned());
+            Ok(i)
+        }
+    }
+}
+
 /// Stores console commands.
 pub struct CmdRegistry {
     cmds: HashMap<String, Cmd>,
+    names: Rc<RefCell<Vec<String>>>,
 }
 
 impl CmdRegistry {
-    pub fn new() -> CmdRegistry {
+    pub fn new(names: Rc<RefCell<Vec<String>>>) -> CmdRegistry {
         CmdRegistry {
             cmds: HashMap::new(),
+            names,
         }
     }
 
@@ -70,9 +85,14 @@ impl CmdRegistry {
         S: AsRef<str>,
     {
         let name = name.as_ref();
+
         match self.cmds.get(name) {
             Some(_) => Err(ConsoleError::DuplicateCommand(name.to_owned()))?,
             None => {
+                if insert_name(&mut self.names.borrow_mut(), name).is_err() {
+                    return Err(ConsoleError::DuplicateCvar(name.into()));
+                }
+
                 self.cmds.insert(name.to_owned(), cmd);
             }
         }
@@ -81,11 +101,22 @@ impl CmdRegistry {
     }
 
     /// Registers a new command with the given name, or replaces one if the name is in use.
-    pub fn insert_or_replace<S>(&mut self, name: S, cmd: Cmd)
+    pub fn insert_or_replace<S>(&mut self, name: S, cmd: Cmd) -> Result<(), ConsoleError>
     where
         S: AsRef<str>,
     {
-        self.cmds.insert(name.as_ref().to_owned(), cmd);
+        let name = name.as_ref();
+
+        // If the name isn't registered as a command and it exists in the name
+        // table, it's a cvar.
+        if !self.cmds.contains_key(name) && insert_name(&mut self.names.borrow_mut(), name).is_err()
+        {
+            return Err(ConsoleError::DuplicateCvar(name.into()));
+        }
+
+        self.cmds.insert(name.into(), cmd);
+
+        Ok(())
     }
 
     /// Removes the command with the given name.
@@ -95,10 +126,17 @@ impl CmdRegistry {
     where
         S: AsRef<str>,
     {
-        match self.cmds.remove(name.as_ref()) {
-            Some(_) => Ok(()),
-            None => Err(ConsoleError::NoSuchCommand(name.as_ref().to_string()))?,
+        if self.cmds.remove(name.as_ref()).is_none() {
+            return Err(ConsoleError::NoSuchCommand(name.as_ref().to_string()))?;
         }
+
+        let mut names = self.names.borrow_mut();
+        match names.binary_search_by(|item| item.as_str().cmp(name.as_ref())) {
+            Ok(i) => drop(names.remove(i)),
+            Err(_) => unreachable!("name in map but not in list: {}", name.as_ref()),
+        }
+
+        Ok(())
     }
 
     /// Executes a command.
@@ -121,6 +159,10 @@ impl CmdRegistry {
         S: AsRef<str>,
     {
         self.cmds.contains_key(name.as_ref())
+    }
+
+    pub fn names(&self) -> Rc<RefCell<Vec<String>>> {
+        self.names.clone()
     }
 }
 
@@ -145,13 +187,15 @@ struct Cvar {
 
 pub struct CvarRegistry {
     cvars: RefCell<HashMap<String, Cvar>>,
+    names: Rc<RefCell<Vec<String>>>,
 }
 
 impl CvarRegistry {
     /// Construct a new empty `CvarRegistry`.
-    pub fn new() -> CvarRegistry {
+    pub fn new(names: Rc<RefCell<Vec<String>>>) -> CvarRegistry {
         CvarRegistry {
             cvars: RefCell::new(HashMap::new()),
+            names,
         }
     }
 
@@ -170,8 +214,12 @@ impl CvarRegistry {
 
         let mut cvars = self.cvars.borrow_mut();
         match cvars.get(name) {
-            Some(_) => Err(ConsoleError::DuplicateCvar(name.to_owned()))?,
+            Some(_) => Err(ConsoleError::DuplicateCvar(name.into()))?,
             None => {
+                if insert_name(&mut self.names.borrow_mut(), name).is_err() {
+                    return Err(ConsoleError::DuplicateCommand(name.into()));
+                }
+
                 cvars.insert(
                     name.to_owned(),
                     Cvar {
@@ -537,6 +585,40 @@ impl Console {
                         _ => (),
                     }
                     String::new()
+                }),
+            )
+            .unwrap();
+
+        let find_names = cmds.borrow().names();
+        cmds.borrow_mut()
+            .insert(
+                "find",
+                Box::new(move |args| match args.len() {
+                    1 => {
+                        let names = find_names.borrow_mut();
+
+                        // Find the index of the first item >= the target.
+                        let start = match names.binary_search_by(|item| item.as_str().cmp(&args[0]))
+                        {
+                            Ok(i) => i,
+                            Err(i) => i,
+                        };
+
+                        // Take every item starting with the target.
+                        let it = (&names[start..])
+                            .iter()
+                            .take_while(move |item| item.starts_with(&args[0]))
+                            .map(|s| s.as_str());
+
+                        let mut output = String::new();
+                        for name in it {
+                            write!(&mut output, "{}\n", name).unwrap();
+                        }
+
+                        output
+                    }
+
+                    _ => "usage: find <cvar or command>".into(),
                 }),
             )
             .unwrap();

--- a/src/common/console/mod.rs
+++ b/src/common/console/mod.rs
@@ -593,6 +593,7 @@ impl Console {
         S: AsRef<str>,
     {
         self.print_impl(s, None);
+        self.print_impl("\n", None);
     }
 
     pub fn println_alert<S>(&self, s: S)
@@ -703,7 +704,7 @@ impl Console {
                                         arg_0,
                                         self.cvars.borrow().get(arg_0).unwrap()
                                     );
-                                    self.print(msg);
+                                    self.println(msg);
                                 }
                             }
                         } else {

--- a/src/common/host.rs
+++ b/src/common/host.rs
@@ -108,7 +108,7 @@ where
         let prev_frame_duration = self.prev_frame_duration;
         if !self.check_frame_duration(prev_frame_duration) {
             // avoid busy waiting if we're running at a really high framerate
-            std::thread::yield_now();
+            std::thread::sleep(std::time::Duration::from_millis(1));
             return;
         }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -34,7 +34,16 @@ pub mod util;
 pub mod vfs;
 pub mod wad;
 
-pub static DEFAULT_BASEDIR: &'static str = "id1";
+pub fn default_base_dir() -> std::path::PathBuf {
+    match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(e) => {
+            log::error!("cannot access current directory: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
 pub const MAX_LIGHTSTYLES: usize = 64;
 
 /// The maximum number of `.pak` files that should be loaded at runtime.


### PR DESCRIPTION
This is a mish-mash of bug fixes and quality-of-life
improvements, including:

- Console errors now flush the line buffer so you can
  actually see why something doesn't work. This was
  broken in the last PR (whoops).
- The viewmodel angle is finally correct! In order to
  correctly position the viewmodel, it has to be
  rotated in the reverse order as everything else, or
  it gets all wonky when the player is facing in the
  -X direction.
- I noticed by chance that the game panicked if the
  cursor couldn't be grabbed, which happened while I
  was tabbed into another workspace. Now it just emits
  a debug message.
- The engine now sleeps for 1 millisecond instead of
  yielding when running above `host_maxfps`. This reduces
  CPU usage by 2/3, from 3% of one core to 1%, on my
  machine.
- The `--base-dir` option is equivalent to the -basedir
  flag in the original game. It indicates to the engine
  the parent of the id1/ directory. If the id1/ directory
  is not found, Richter now helpfully logs an error
  explaining the problem and how to solve it. This is an
  improvement over the previous behavior, shared by the
  original game, which simply presents the cryptic message
  "gfx/palette.lmp not found".
- The `find` command has been implemented, which allows
  searching for cvars and commands from the console.